### PR TITLE
Add currencies filter to ListAccounts

### DIFF
--- a/packages/client/src/LedgerLivePlatformSDK.ts
+++ b/packages/client/src/LedgerLivePlatformSDK.ts
@@ -261,7 +261,15 @@ export default class LedgerLivePlatformSDK {
    */
   async listAccounts(
     params: {
+      /**
+       * Include tokens accounts in the results
+       */
       includeTokens?: boolean;
+      /**
+       * Select a set of currencies by id to filter accounts agains.
+       * Globing is enabled
+       */
+      currencies?: string[];
     } = {}
   ): Promise<Account[]> {
     const rawAccounts = await this._request<RawAccount[]>(

--- a/packages/server/src/handlers/listAccounts.test.ts
+++ b/packages/server/src/handlers/listAccounts.test.ts
@@ -164,4 +164,63 @@ describe("listAccounts", () => {
 
     expect(res).toEqual(serverAccounts);
   });
+
+  describe("currencies filter", () => {
+    test("should return all accounts if no currencies filter is provided", () => {
+      const res = listAccounts(
+        { params: { includeTokens: true, currencies: undefined } },
+        {
+          logger: defaultLogger,
+          accounts: serverAccounts,
+          currencies: serverCurrencies,
+        }
+      ) as Currency[];
+
+      expect(res).toEqual(serverAccounts);
+    });
+
+    test("should filter accounts with currency name", () => {
+      const res = listAccounts(
+        {
+          params: {
+            includeTokens: true,
+            currencies: ["bitcoin"],
+          },
+        },
+        {
+          logger: defaultLogger,
+          accounts: serverAccounts,
+          currencies: serverCurrencies,
+        }
+      ) as Currency[];
+
+      expect(res).toEqual([cryptoAccounts[0]]);
+    });
+
+    test("should filter accounts with currency regex", () => {
+      const res = listAccounts(
+        { params: { includeTokens: true, currencies: ["ethereum/*"] } },
+        {
+          logger: defaultLogger,
+          accounts: serverAccounts,
+          currencies: serverCurrencies,
+        }
+      ) as Currency[];
+
+      expect(res).toEqual(tokenAccounts);
+    });
+
+    test("should include currency and tokens accounts when filtering with currency name", () => {
+      const res = listAccounts(
+        { params: { includeTokens: true, currencies: ["ethereum"] } },
+        {
+          logger: defaultLogger,
+          accounts: serverAccounts,
+          currencies: serverCurrencies,
+        }
+      ) as Currency[];
+
+      expect(res).toEqual([cryptoAccounts[1], ...tokenAccounts]);
+    });
+  });
 });

--- a/spec/rpc/README.md
+++ b/spec/rpc/README.md
@@ -146,7 +146,8 @@ Returns the list of accounts added by the current user on Ledger Live.
 
 #### Parameters
 
-- `includeTokens? (boolean)`: Allow the user to pick token accounts.
+- `currencies? (string[])`: Select a set of currencies by id. Globing is enabled.
+- `includeTokens? (boolean)`: Include tokens in the results.
 
 #### Request
 
@@ -156,6 +157,7 @@ Returns the list of accounts added by the current user on Ledger Live.
   "id": 1,
   "method": "account.list",
   "params": {
+    "currencies": [],
     "includeTokens": false
   }
 }


### PR DESCRIPTION
Allow SDK user to filter listed accounts based on a currencies filter, similar to the currencies filter for ListCurrencies

fixes #15 

Depends on:
- #14 