### PR TITLE
chore: release CI [LIVE-3193]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: pnpm publish-packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format:check": "turbo run format:check",
     "format:fix": "turbo run format:fix",
     "prepare": "husky install",
-    "publish-packages": "turbo run build lint test && changeset publish"
+    "publish-packages": "turbo run build lint && changeset publish"
   },
   "lint-staged": {
     "*.ts": "eslint --fix"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "packages/*"
   ],
   "scripts": {
+    "clean": "git clean -fdX",
+    "changelog": "changeset add",
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
@@ -14,7 +16,8 @@
     "test": "turbo run test",
     "format:check": "turbo run format:check",
     "format:fix": "turbo run format:fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "publish-packages": "turbo run build lint test && changeset publish"
   },
   "lint-staged": {
     "*.ts": "eslint --fix"
@@ -32,5 +35,5 @@
     "npm": ">=7.0.0",
     "node": ">=16.0.0"
   },
-  "packageManager": "pnpm@7.12.1"
+  "packageManager": "pnpm@7.13.4"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-api-client",
-  "version": "0.8.1",
+  "version": "0.1.0",
   "repository": "git@github.com:LedgerHQ/wallet-api.git",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-config-custom",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Instead of doing a pre-release (`next` something) on `main` and tag to do the release, we use the changesets action (https://github.com/changesets/action) to help us create and update a PR whenever there is new changesets on `main`