### PR TITLE
Add github issues notebooks

### DIFF
--- a/.vscode/notebooks/my-work.github-issues
+++ b/.vscode/notebooks/my-work.github-issues
@@ -1,0 +1,72 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Bugs, Debt, Features..."
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "#### My Bugs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos assignee:@me is:open label:bug"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "### Pull Requests"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🔍 Awaiting my review"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:pr review-requested:@me"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✅ Approved"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open is:pr review:approved draft:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "⌛ Pending Approval"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open is:pr review:required draft:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📄 Drafts"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open is:pr draft:true"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "##### `Config`"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of repos we work in\n$repos=repo:LedgerHQ/ledger-live repo:LedgerHQ/ledger-live-wagmi-connector repo:LedgerHQ/live-app-sdk repo:LedgerHQ/wallet-connect-live-app repo:LedgerHQ/eth-dapp-browser repo:LedgerHQ/cra-template-live-app repo:LedgerHQ/platform-app-debug repo:LedgerHQ/platform-app-test-exchange repo:LedgerHQ/platform-app-web-browser repo:LedgerHQ/manifest-api repo:LedgerHQ/eth-dapp-browser-test-dapp repo:LedgerHQ/platform-app-coinify repo:LedgerHQ/iframe-provider repo:LedgerHQ/wallet-api"
+  }
+]

--- a/.vscode/notebooks/team-inbox.github-issues
+++ b/.vscode/notebooks/team-inbox.github-issues
@@ -1,0 +1,77 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Team inbox\n\nAll pull requests and issues assigned to the team."
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Pull requests assigned to the team\n\nOpen pull requests (not in draft) awaiting review from the team"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "type:pr team-review-requested:$TEAM is:open archived:false sort:created-asc draft:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Issues assigned to the team"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "type:issue team-review-requested:$TEAM is:open archived:false sort:created-desc"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Open pull requests in the repos we own"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$REPOS type:pr is:open draft:false -label:dependencies"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🔍 Awaiting review"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$REPOS type:pr is:open review:required -label:dependencies"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "### Dependencies to update"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$REPOS type:pr is:open draft:false label:dependencies"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Open issues in the repos we own"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$REPOS type:issue is:open"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "`Config`: define macros used accross queries"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$TEAM=LedgerHQ/live-platform-and-services\n\n// repo we own\n$REPOS=repo:LedgerHQ/ledger-live-wagmi-connector repo:LedgerHQ/live-app-sdk repo:LedgerHQ/wallet-connect-live-app repo:LedgerHQ/eth-dapp-browser repo:LedgerHQ/cra-template-live-app repo:LedgerHQ/platform-app-debug repo:LedgerHQ/platform-app-test-exchange repo:LedgerHQ/platform-app-web-browser repo:LedgerHQ/manifest-api repo:LedgerHQ/eth-dapp-browser-test-dapp repo:LedgerHQ/platform-app-coinify repo:LedgerHQ/iframe-provider repo:LedgerHQ/wallet-api"
+  }
+]


### PR DESCRIPTION
Add github issues notebooks to easily track all PR and issues related to the team at large in a single place.
Furthermore, since notebooks are versioned, they can easily shared, updated and reviewed like any other textefile (configuration, doc, code) 🙌 

You will need the [GitHub issue notebooks extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks) to get the full out of this. 

Some inspirations from the vscode team:
https://github.com/microsoft/vscode/tree/main/.vscode/notebooks

cf. https://code.visualstudio.com/blogs/2021/11/08/custom-notebooks#_github-issues-notebook

