### PR TITLE
fix type on server handlers to match signature on client side

### DIFF
--- a/.changeset/fifty-swans-cry.md
+++ b/.changeset/fifty-swans-cry.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-core": patch
+"@ledgerhq/wallet-api-server": patch
+---
+
+fix type on server handlers to match signature on client side

--- a/packages/core/src/spec/types/AccountList.ts
+++ b/packages/core/src/spec/types/AccountList.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import { schemaRawAccount } from "../../accounts";
 
-const schemaAccountListParams = z.object({
-  currencyIds: z.array(z.string()).optional(),
-});
+const schemaAccountListParams = z
+  .object({
+    currencyIds: z.array(z.string()).optional(),
+  })
+  .optional();
 
 const schemaAccountListResults = z.object({
   rawAccounts: z.array(schemaRawAccount),

--- a/packages/core/src/spec/types/CurrencyList.ts
+++ b/packages/core/src/spec/types/CurrencyList.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import { schemaCurrency } from "../../currencies";
 
-const schemaCurrencyListParams = z.object({
-  currencyIds: z.array(z.string()).optional(),
-});
+const schemaCurrencyListParams = z
+  .object({
+    currencyIds: z.array(z.string()).optional(),
+  })
+  .optional();
 
 const schemaCurrencyListResult = z.object({
   currencies: z.array(schemaCurrency),

--- a/packages/server/src/internalHandlers/account.ts
+++ b/packages/server/src/internalHandlers/account.ts
@@ -71,7 +71,7 @@ export const request: RPCHandler<AccountRequest["result"]> = async (
 export const list: RPCHandler<AccountList["result"]> = async (req, context) => {
   const safeParams = schemaAccountList.params.parse(req.params);
 
-  const { currencyIds } = safeParams;
+  const { currencyIds } = safeParams || {};
 
   const filteredAccounts$ = currencyIds
     ? context.accounts$.pipe(

--- a/packages/server/src/internalHandlers/currency.ts
+++ b/packages/server/src/internalHandlers/currency.ts
@@ -21,7 +21,7 @@ export const list: RPCHandler<CurrencyList["result"]> = async (
 ) => {
   const safeParams = schemaCurrencyList.params.parse(req.params);
 
-  const { currencyIds } = safeParams;
+  const { currencyIds } = safeParams || {};
 
   const allCurrencies = await firstValueFrom(context.currencies$);
 


### PR DESCRIPTION
Fix type of `currency.list` and `account.list` server handlers to match method signatures on client side ([this](https://github.com/LedgerHQ/wallet-api/blob/main/packages/client/src/WalletAPIClient.ts#L224-L239) and [this](https://github.com/LedgerHQ/wallet-api/blob/main/packages/client/src/WalletAPIClient.ts#L157-L170) respectively).

For example, this is valid from the client side:
`walletAPIClientInstance.listCurrencies()`

But is not from the server side (handler), which would request this instead:
`walletAPIClientInstance.listCurrencies({})`

📝  Notes:
- Consistency of methods signature schema / types should be enforced between client and server