### PR TITLE
chore: better eslint next config

### DIFF
--- a/apps/wallet-api-tools/.eslintrc.js
+++ b/apps/wallet-api-tools/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: ["custom/next"],
+  parserOptions: {
+    project: ["./tsconfig.json"],
+    tsconfigRootDir: __dirname,
+    babelOptions: {
+      presets: [require.resolve("next/babel")], // https://github.com/vercel/next.js/issues/40687#issuecomment-1264177674
+    },
+  },
+  rules: {},
+};

--- a/apps/wallet-api-tools/.eslintrc.json
+++ b/apps/wallet-api-tools/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "root": true,
-  "extends": ["next"],
-  "rules": {}
-}

--- a/apps/wallet-api-tools/package.json
+++ b/apps/wallet-api-tools/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/view": "^6.8.0",
     "@ledgerhq/wallet-api-core": "workspace:*",
     "@ledgerhq/wallet-api-simulator": "workspace:*",
     "@next/font": "13.1.1",
@@ -21,8 +22,6 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.10",
     "@uiw/react-codemirror": "^4.19.5",
-    "eslint": "8.31.0",
-    "eslint-config-next": "13.1.1",
     "flowbite": "^1.6.0",
     "next": "^13.1.1",
     "react": "18.2.0",
@@ -34,6 +33,8 @@
   "devDependencies": {
     "@types/uuid": "^9.0.0",
     "autoprefixer": "^10.4.13",
+    "eslint": "^8.33.0",
+    "eslint-config-custom": "workspace:*",
     "postcss": "^8.4.20",
     "postcss-import": "^15.1.0",
     "tailwindcss": "^3.2.4"

--- a/apps/wallet-api-tools/src/Input.tsx
+++ b/apps/wallet-api-tools/src/Input.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
-import CodeMirror from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
+import CodeMirror from "@uiw/react-codemirror";
+import { useCallback, useState } from "react";
 import { TemplateSelector } from "./TemplateSelector";
 
 export type InputProps = {
@@ -12,8 +12,8 @@ export type InputProps = {
 
 export function Input({ onSend, onClear }: InputProps) {
   const [value, setValue] = useState("");
-  const onChange = useCallback((value: string) => {
-    setValue(value);
+  const onChange = useCallback((input: string) => {
+    setValue(input);
   }, []);
 
   const handleSend = useCallback(() => {

--- a/apps/wallet-api-tools/src/TemplateSelector/index.tsx
+++ b/apps/wallet-api-tools/src/TemplateSelector/index.tsx
@@ -1,11 +1,10 @@
-import React from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 import "./style.css";
 
 type Option = {
   label: string;
-  value: any;
+  value: object;
 };
 
 type Group = {
@@ -210,9 +209,9 @@ const data: Group[] = [
     ],
   },
 ];
-  
+
 type TemplateSelectorProps = {
-  onSelectTemplate: (value: string) => void;
+  onSelectTemplate: (value: object) => void;
 };
 
 export function TemplateSelector({ onSelectTemplate }: TemplateSelectorProps) {

--- a/packages/eslint-config-custom/next.js
+++ b/packages/eslint-config-custom/next.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ["next", "turbo", "plugin:prettier/recommended"],
+  rules: {
+    "@next/next/no-html-link-for-pages": "off",
+    "react/jsx-key": "off",
+  },
+};

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -10,6 +10,7 @@
     "eslint": "^8.26.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-next": "13.1.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-turbo": "^0.0.4",
     "eslint-plugin-import": "^2.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ importers:
   apps/wallet-api-tools:
     specifiers:
       '@codemirror/lang-json': ^6.0.1
+      '@codemirror/view': ^6.8.0
       '@ledgerhq/wallet-api-core': workspace:*
       '@ledgerhq/wallet-api-simulator': workspace:*
       '@next/font': 13.1.1
@@ -35,8 +36,8 @@ importers:
       '@types/uuid': ^9.0.0
       '@uiw/react-codemirror': ^4.19.5
       autoprefixer: ^10.4.13
-      eslint: 8.31.0
-      eslint-config-next: 13.1.1
+      eslint: ^8.33.0
+      eslint-config-custom: workspace:*
       flowbite: ^1.6.0
       next: ^13.1.1
       postcss: ^8.4.20
@@ -49,6 +50,7 @@ importers:
       zod: ^3.20.2
     dependencies:
       '@codemirror/lang-json': 6.0.1
+      '@codemirror/view': 6.8.0
       '@ledgerhq/wallet-api-core': link:../../packages/core
       '@ledgerhq/wallet-api-simulator': link:../../packages/simulator
       '@next/font': 13.1.1
@@ -58,9 +60,7 @@ importers:
       '@types/node': 18.11.18
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
-      '@uiw/react-codemirror': 4.19.7_pzrqepnlx4uklbalwyntc26e4u
-      eslint: 8.31.0
-      eslint-config-next: 13.1.1_iukboom6ndih5an6iafl45j2fe
+      '@uiw/react-codemirror': 4.19.7_pvvua64zq6gcnpmawjrwlwkpii
       flowbite: 1.6.2
       next: 13.1.4_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
@@ -71,6 +71,8 @@ importers:
     devDependencies:
       '@types/uuid': 9.0.0
       autoprefixer: 10.4.13_postcss@8.4.20
+      eslint: 8.33.0
+      eslint-config-custom: link:../../packages/eslint-config-custom
       postcss: 8.4.20
       postcss-import: 15.1.0_postcss@8.4.20
       tailwindcss: 3.2.4_postcss@8.4.20
@@ -104,7 +106,7 @@ importers:
       jest-environment-jsdom: 29.2.2
       jest-shared-config: link:../jest-shared-config
       prettier: 2.7.1
-      ts-jest: 29.0.3_iq2aio43xcflbedzg2rceiytyq
+      ts-jest: 29.0.3_2gcdg7c5hzdfd67o3khlosdlhu
       ts-node: 10.9.1_7jzoohtnaegavowzoeccrsbhty
       typescript: 4.8.4
 
@@ -139,7 +141,7 @@ importers:
       jest: 29.1.2_zbszuqcpgvqti4gsbgzr4pxrbm
       jest-environment-jsdom: 29.2.2
       jest-shared-config: link:../jest-shared-config
-      ts-jest: 29.0.3_4uxyyn7jaovnuu2mldkagoyetq
+      ts-jest: 29.0.3_2gcdg7c5hzdfd67o3khlosdlhu
       ts-node: 10.9.1_7jzoohtnaegavowzoeccrsbhty
       typescript: 4.8.4
 
@@ -150,6 +152,7 @@ importers:
       eslint: ^8.26.0
       eslint-config-airbnb-base: ^15.0.0
       eslint-config-airbnb-typescript: ^17.0.0
+      eslint-config-next: 13.1.1
       eslint-config-prettier: ^8.5.0
       eslint-config-turbo: ^0.0.4
       eslint-plugin-import: ^2.26.0
@@ -163,6 +166,7 @@ importers:
       eslint: 8.26.0
       eslint-config-airbnb-base: 15.0.0_mynvxvmq5qtyojffiqgev4x7mm
       eslint-config-airbnb-typescript: 17.0.0_yxexh7lkdp6zshkc5735fso3gu
+      eslint-config-next: 13.1.1_wyqvi574yv7oiwfeinomdzmc3m
       eslint-config-prettier: 8.5.0_eslint@8.26.0
       eslint-config-turbo: 0.0.4_eslint@8.26.0
       eslint-plugin-import: 2.26.0_c2flhriocdzler6lrwbyxxyoca
@@ -206,7 +210,7 @@ importers:
       jest-environment-jsdom: 29.2.2
       jest-shared-config: link:../jest-shared-config
       prettier: 2.7.1
-      ts-jest: 29.0.3_dchrsngysiewhktoqrskv62uju
+      ts-jest: 29.0.3_r24ewcothphvclnu77pxb4u4se
       ts-node: 10.9.1_7jzoohtnaegavowzoeccrsbhty
       typescript: 4.8.4
 
@@ -223,7 +227,7 @@ importers:
     dependencies:
       '@ledgerhq/wallet-api-core': link:../core
       '@ledgerhq/wallet-api-manifest-validator': link:../manifest-validator
-      clipanion: 3.2.0-rc.13_typanion@3.12.1
+      clipanion: 3.2.0-rc.13
     devDependencies:
       '@tsconfig/node18-strictest': 1.0.0
       '@types/node': 18.11.8
@@ -268,7 +272,7 @@ importers:
       jest-shared-config: link:../jest-shared-config
       react: 18.2.0
       rxjs: 7.8.0
-      ts-jest: 29.0.3_4uxyyn7jaovnuu2mldkagoyetq
+      ts-jest: 29.0.3_2gcdg7c5hzdfd67o3khlosdlhu
       ts-node: 10.9.1_7jzoohtnaegavowzoeccrsbhty
       typescript: 4.8.4
 
@@ -309,7 +313,7 @@ importers:
       jest: 29.1.2_zbszuqcpgvqti4gsbgzr4pxrbm
       jest-environment-jsdom: 29.2.2
       jest-shared-config: link:../jest-shared-config
-      ts-jest: 29.0.3_4uxyyn7jaovnuu2mldkagoyetq
+      ts-jest: 29.0.3_2gcdg7c5hzdfd67o3khlosdlhu
       ts-node: 10.9.1_7jzoohtnaegavowzoeccrsbhty
       typescript: 4.8.4
 
@@ -525,6 +529,7 @@ packages:
   /@babel/compat-data/7.20.5:
     resolution: {integrity: sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/core/7.12.9:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
@@ -594,6 +599,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/generator/7.19.0:
     resolution: {integrity: sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==}
@@ -611,6 +617,7 @@ packages:
       '@babel/types': 7.20.5
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: false
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -651,6 +658,7 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
+    dev: false
 
   /@babel/helper-create-class-features-plugin/7.20.5_@babel+core@7.20.5:
     resolution: {integrity: sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==}
@@ -764,6 +772,7 @@ packages:
       '@babel/types': 7.20.5
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -825,6 +834,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.5
+    dev: false
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
@@ -846,6 +856,7 @@ packages:
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-validator-identifier/7.18.6:
     resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
@@ -891,6 +902,7 @@ packages:
       '@babel/types': 7.20.5
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -913,6 +925,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.5
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.5:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -2084,6 +2097,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/types/7.19.0:
     resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
@@ -2100,6 +2114,7 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: false
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2307,17 +2322,15 @@ packages:
       prettier: 2.7.1
     dev: true
 
-  /@codemirror/autocomplete/6.4.0_3jfk5zzaw77h3sqp5wt6b7asku:
+  /@codemirror/autocomplete/6.4.0_adfixyximyvg2c27h43sbnh23e:
     resolution: {integrity: sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==}
     peerDependencies:
-      '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
-      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       '@lezer/common': 1.0.2
     dev: false
 
@@ -2326,7 +2339,7 @@ packages:
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       '@lezer/common': 1.0.2
     dev: false
 
@@ -2341,7 +2354,7 @@ packages:
     resolution: {integrity: sha512-Wzb7GnNj8vnEtbPWiOy9H0m1fBtE28kepQNGLXekU2EEZv43BF865VKITUn+NoV8OpW6gRtvm29YEhqm46927Q==}
     dependencies:
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       '@lezer/common': 1.0.2
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.3.1
@@ -2352,7 +2365,7 @@ packages:
     resolution: {integrity: sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==}
     dependencies:
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       crelt: 1.0.5
     dev: false
 
@@ -2360,7 +2373,7 @@ packages:
     resolution: {integrity: sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==}
     dependencies:
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       crelt: 1.0.5
     dev: false
 
@@ -2373,12 +2386,12 @@ packages:
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
       '@lezer/highlight': 1.1.3
     dev: false
 
-  /@codemirror/view/6.7.3:
-    resolution: {integrity: sha512-Lt+4POnhXrZFfHOdPzXEHxrzwdy7cjqYlMkOWvoFGi6/bAsjzlFfr0NY3B15B/PGx+cDFgM1hlc12wvYeZbGLw==}
+  /@codemirror/view/6.8.0:
+    resolution: {integrity: sha512-9LR8uwkivHTvZxiYCRreO6VYleZUVbpvZ1+4oCQT2RU0VbpL3nYgO2/1hhgpIWh5mrIj48Rj+AGVFIr2RN4Zcg==}
     dependencies:
       '@codemirror/state': 6.2.0
       style-mod: 4.0.0
@@ -3361,7 +3374,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.0
-      globals: 13.19.0
+      globals: 13.20.0
       ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -3369,7 +3382,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@floating-ui/core/0.7.3:
     resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
@@ -3422,7 +3435,7 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@humanwhocodes/module-importer/1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -5201,7 +5214,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.48.2_iukboom6ndih5an6iafl45j2fe:
+  /@typescript-eslint/parser/5.48.2_wyqvi574yv7oiwfeinomdzmc3m:
     resolution: {integrity: sha512-38zMsKsG2sIuM5Oi/olurGwYJXzmtdsHhn5mI/pQogP+BjYVkK5iRazCQ8RGS0V+YLk282uWElN70zAAUmaYHw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5213,10 +5226,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.48.2
       '@typescript-eslint/types': 5.48.2
-      '@typescript-eslint/typescript-estree': 5.48.2_typescript@4.9.4
+      '@typescript-eslint/typescript-estree': 5.48.2_typescript@4.8.4
       debug: 4.3.4
-      eslint: 8.31.0
-      typescript: 4.9.4
+      eslint: 8.26.0
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5288,7 +5301,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.48.2_typescript@4.9.4:
+  /@typescript-eslint/typescript-estree/5.48.2_typescript@4.8.4:
     resolution: {integrity: sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5303,8 +5316,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.4
-      typescript: 4.9.4
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5345,34 +5358,24 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: false
 
-  /@uiw/codemirror-extensions-basic-setup/4.19.7_z4w2cb7jeeiewgtgrbfykr2vnq:
+  /@uiw/codemirror-extensions-basic-setup/4.19.7_@codemirror+view@6.8.0:
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
     peerDependencies:
-      '@codemirror/autocomplete': '>=6.0.0'
-      '@codemirror/commands': '>=6.0.0'
-      '@codemirror/language': '>=6.0.0'
-      '@codemirror/lint': '>=6.0.0'
-      '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.4.0_3jfk5zzaw77h3sqp5wt6b7asku
+      '@codemirror/autocomplete': 6.4.0_adfixyximyvg2c27h43sbnh23e
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
+      '@codemirror/view': 6.8.0
     dev: false
 
-  /@uiw/react-codemirror/4.19.7_pzrqepnlx4uklbalwyntc26e4u:
+  /@uiw/react-codemirror/4.19.7_pvvua64zq6gcnpmawjrwlwkpii:
     resolution: {integrity: sha512-IHvpYWVSdiaHX0Fk6oY6YyAJigDnyvSpWKNUTRzsMNxB+8/wqZ8lior4TprXH0zyLxW5F1+bTyifFFTeg+X3Sw==}
     peerDependencies:
-      '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
-      codemirror: '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
@@ -5380,16 +5383,11 @@ packages:
       '@codemirror/commands': 6.2.0
       '@codemirror/state': 6.2.0
       '@codemirror/theme-one-dark': 6.1.0
-      '@codemirror/view': 6.7.3
-      '@uiw/codemirror-extensions-basic-setup': 4.19.7_z4w2cb7jeeiewgtgrbfykr2vnq
-      codemirror: 6.0.1_@lezer+common@1.0.2
+      '@codemirror/view': 6.8.0
+      '@uiw/codemirror-extensions-basic-setup': 4.19.7_@codemirror+view@6.8.0
+      codemirror: 6.0.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@codemirror/autocomplete'
-      - '@codemirror/language'
-      - '@codemirror/lint'
-      - '@codemirror/search'
     dev: false
 
   /@webassemblyjs/ast/1.11.1:
@@ -5576,10 +5574,8 @@ packages:
       ajv: 8.11.0
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6434,10 +6430,8 @@ packages:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
 
-  /clipanion/3.2.0-rc.13_typanion@3.12.1:
+  /clipanion/3.2.0-rc.13:
     resolution: {integrity: sha512-JYuPIaZZOl4nTUP4BMXmHGxYkAD2gc0m5GxZKr2eKEjquyFj/WBbkERDesnUsQKewUmWvBzzxdbf8WQ/GBDduQ==}
-    peerDependencies:
-      typanion: '*'
     dependencies:
       typanion: 3.12.1
     dev: false
@@ -6496,18 +6490,16 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror/6.0.1_@lezer+common@1.0.2:
+  /codemirror/6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0_3jfk5zzaw77h3sqp5wt6b7asku
+      '@codemirror/autocomplete': 6.4.0_adfixyximyvg2c27h43sbnh23e
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.3
-    transitivePeerDependencies:
-      - '@lezer/common'
+      '@codemirror/view': 6.8.0
     dev: false
 
   /collapse-white-space/1.0.6:
@@ -7596,7 +7588,7 @@ packages:
       eslint-plugin-import: 2.26.0_c2flhriocdzler6lrwbyxxyoca
     dev: false
 
-  /eslint-config-next/13.1.1_iukboom6ndih5an6iafl45j2fe:
+  /eslint-config-next/13.1.1_wyqvi574yv7oiwfeinomdzmc3m:
     resolution: {integrity: sha512-/5S2XGWlGaiqrRhzpn51ux5JUSLwx8PVK2keLi5xk7QmhfYB8PqE6R6SlVw6hgnf/VexvUXSrlNJ/su00NhtHQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -7607,15 +7599,15 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.1.1
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.48.2_iukboom6ndih5an6iafl45j2fe
-      eslint: 8.31.0
+      '@typescript-eslint/parser': 5.48.2_wyqvi574yv7oiwfeinomdzmc3m
+      eslint: 8.26.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.3_ol7jqilc3wemtdbq3nzhywgxq4
-      eslint-plugin-import: 2.26.0_eslint@8.31.0
-      eslint-plugin-jsx-a11y: 6.7.1_eslint@8.31.0
-      eslint-plugin-react: 7.32.1_eslint@8.31.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.31.0
-      typescript: 4.9.4
+      eslint-import-resolver-typescript: 3.5.3_mynvxvmq5qtyojffiqgev4x7mm
+      eslint-plugin-import: 2.26.0_6tca7hbgqcy6vxtgfn4kow2ueq
+      eslint-plugin-jsx-a11y: 6.7.1_eslint@8.26.0
+      eslint-plugin-react: 7.32.1_eslint@8.26.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.26.0
+      typescript: 4.8.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -7648,7 +7640,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript/3.5.3_ol7jqilc3wemtdbq3nzhywgxq4:
+  /eslint-import-resolver-typescript/3.5.3_mynvxvmq5qtyojffiqgev4x7mm:
     resolution: {integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7657,8 +7649,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
-      eslint: 8.31.0
-      eslint-plugin-import: 2.26.0_eslint@8.31.0
+      eslint: 8.26.0
+      eslint-plugin-import: 2.26.0_6tca7hbgqcy6vxtgfn4kow2ueq
       get-tsconfig: 4.3.0
       globby: 13.1.3
       is-core-module: 2.11.0
@@ -7697,7 +7689,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.4_rahvyjeqqlq6ogimp3cp7kgkfq:
+  /eslint-module-utils/2.7.4_zvla57idmo4e2ftgwma6gixsgm:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7718,10 +7710,43 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.48.2_wyqvi574yv7oiwfeinomdzmc3m
       debug: 3.2.7
-      eslint: 8.31.0
+      eslint: 8.26.0
       eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 3.5.3_mynvxvmq5qtyojffiqgev4x7mm
     transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-plugin-import/2.26.0_6tca7hbgqcy6vxtgfn4kow2ueq:
+    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.48.2_wyqvi574yv7oiwfeinomdzmc3m
+      array-includes: 3.1.5
+      array.prototype.flat: 1.3.0
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 8.26.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-module-utils: 2.7.4_zvla57idmo4e2ftgwma6gixsgm
+      has: 1.0.3
+      is-core-module: 2.10.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.5
+      resolve: 1.22.1
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
@@ -7756,37 +7781,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-import/2.26.0_eslint@8.31.0:
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      array-includes: 3.1.5
-      array.prototype.flat: 1.3.0
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.31.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_rahvyjeqqlq6ogimp3cp7kgkfq
-      has: 1.0.3
-      is-core-module: 2.10.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.5
-      resolve: 1.22.1
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: false
-
-  /eslint-plugin-jsx-a11y/6.7.1_eslint@8.31.0:
+  /eslint-plugin-jsx-a11y/6.7.1_eslint@8.26.0:
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -7801,7 +7796,7 @@ packages:
       axobject-query: 3.1.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.31.0
+      eslint: 8.26.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
@@ -7837,16 +7832,7 @@ packages:
       eslint: 8.26.0
     dev: false
 
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.31.0:
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.31.0
-    dev: false
-
-  /eslint-plugin-react/7.32.1_eslint@8.31.0:
+  /eslint-plugin-react/7.32.1_eslint@8.26.0:
     resolution: {integrity: sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7856,7 +7842,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.31.0
+      eslint: 8.26.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -7901,15 +7887,15 @@ packages:
       eslint: 8.26.0
       eslint-visitor-keys: 2.1.0
 
-  /eslint-utils/3.0.0_eslint@8.31.0:
+  /eslint-utils/3.0.0_eslint@8.33.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.31.0
+      eslint: 8.33.0
       eslint-visitor-keys: 2.1.0
-    dev: false
+    dev: true
 
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -7966,8 +7952,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint/8.31.0:
-    resolution: {integrity: sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==}
+  /eslint/8.33.0:
+    resolution: {integrity: sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -7982,7 +7968,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.31.0
+      eslint-utils: 3.0.0_eslint@8.33.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.0
       esquery: 1.4.0
@@ -7991,7 +7977,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.19.0
+      globals: 13.20.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       import-fresh: 3.3.0
@@ -8012,7 +7998,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /espree/9.4.0:
     resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
@@ -8641,12 +8627,12 @@ packages:
     dependencies:
       type-fest: 0.20.2
 
-  /globals/13.19.0:
-    resolution: {integrity: sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==}
+  /globals/13.20.0:
+    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: false
+    dev: true
 
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
@@ -13137,7 +13123,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: false
 
@@ -13579,7 +13565,7 @@ packages:
       es-abstract: 1.20.4
       get-intrinsic: 1.1.3
       has-symbols: 1.0.3
-      internal-slot: 1.0.3
+      internal-slot: 1.0.4
       regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
     dev: false
@@ -13964,7 +13950,7 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: false
 
-  /ts-jest/29.0.3_4uxyyn7jaovnuu2mldkagoyetq:
+  /ts-jest/29.0.3_2gcdg7c5hzdfd67o3khlosdlhu:
     resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -13985,7 +13971,6 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.20.5
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.1.2_zbszuqcpgvqti4gsbgzr4pxrbm
@@ -13998,7 +13983,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest/29.0.3_dchrsngysiewhktoqrskv62uju:
+  /ts-jest/29.0.3_r24ewcothphvclnu77pxb4u4se:
     resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -14019,44 +14004,9 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.20.5
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.3.1_zbszuqcpgvqti4gsbgzr4pxrbm
-      jest-util: 29.3.1
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.8
-      typescript: 4.8.4
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest/29.0.3_iq2aio43xcflbedzg2rceiytyq:
-    resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.19.1
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.1.2_zbszuqcpgvqti4gsbgzr4pxrbm
       jest-util: 29.3.1
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -14120,16 +14070,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.4
-    dev: false
-
-  /tsutils/3.21.0_typescript@4.9.4:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.9.4
     dev: false
 
   /tty-table/4.1.6:


### PR DESCRIPTION
Uses typescript & prettier with next for eslint
Also fixed lint issues and always use 2 spaces for `JSON.stringify`