### PR TITLE
fix build exports for cross referential packages

### DIFF
--- a/.changeset/brown-rings-mix.md
+++ b/.changeset/brown-rings-mix.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/wallet-api-client": minor
+"@ledgerhq/wallet-api-client-react": minor
+"@ledgerhq/wallet-api-manifest-validator": minor
+"@ledgerhq/wallet-api-server": minor
+"@ledgerhq/wallet-api-simulator": minor
+---
+
+Updates module, main and types fields in package.json files of cross-referential packages, allowing the packages to be externally imported

--- a/packages/client-react/package.json
+++ b/packages/client-react/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "repository": "git@github.com:LedgerHQ/wallet-api.git",
   "license": "Apache-2.0",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+    "main": "lib/client-react/src/index.js",
+  "module": "lib-es/client-react/src/index.js",
+  "types": "lib/client-react/src/index.d.ts",
   "files": [
     "/lib",
     "/lib-es"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "repository": "git@github.com:LedgerHQ/wallet-api.git",
   "license": "Apache-2.0",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/client/src/index.js",
+  "module": "lib-es/client/src/index.js",
+  "types": "lib/client/src/index.d.ts",
   "files": [
     "/lib",
     "/lib-es"

--- a/packages/manifest-validator/package.json
+++ b/packages/manifest-validator/package.json
@@ -3,9 +3,9 @@
   "version": "0.5.3",
   "description": "This package checks if your manifest.json file meets the requirements for Ledger wallet App manifest submission.",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/manifest-validator/src/index.js",
+  "module": "lib-es/manifest-validator/src/index.js",
+  "types": "lib/manifest-validator/src/index.d.ts",
   "files": [
     "/lib",
     "/lib-es",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,9 +2,9 @@
   "name": "@ledgerhq/wallet-api-server",
   "version": "1.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/server/src/index.js",
+  "module": "lib-es/server/src/index.js",
+  "types": "lib/server/src/index.d.ts",
   "files": [
     "/lib",
     "/lib-es"

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -2,9 +2,9 @@
   "name": "@ledgerhq/wallet-api-simulator",
   "version": "1.0.0",
   "license": "MIT",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/simulator/src/index.js",
+  "module": "lib-es/simulator/src/index.js",
+  "types": "lib/simulator/src/index.d.ts",
   "files": [
     "/lib",
     "/lib-es"


### PR DESCRIPTION
**Related Issue**
Closes #204, see for more details and discussion

**Summary**
Currently when installing the package from NPM, it is not possible to import anything from packages that reference other monorepo packages. For a full explanation of this please [see this comment.](https://github.com/LedgerHQ/wallet-api/issues/204#issuecomment-1643171400)

Note that this issue only seems to occur for packages _which reference other packages_.

**Changes**
 - Points the `"main"`, `"module"` and `"types"` `package.json` fields of cross referential  packages to the true build location of each respective package, allowing imports.

**Testing**
 - Pointed my consuming application to local version of package, import warnings removed and build works again.