### PR TITLE
fix: missing baseUrl for prod tsconfig

### DIFF
--- a/.changeset/rare-roses-cross.md
+++ b/.changeset/rare-roses-cross.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/wallet-api-manifest-validator": patch
+"@ledgerhq/wallet-api-client-react": patch
+"@ledgerhq/wallet-api-simulator": patch
+"@ledgerhq/wallet-api-client": patch
+"@ledgerhq/wallet-api-server": patch
+"@ledgerhq/wallet-api-core": patch
+---
+
+fix: missing baseUrl for prod tsconfig

--- a/packages/client-react/prod-esm.tsconfig.json
+++ b/packages/client-react/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/client-react/prod.tsconfig.json
+++ b/packages/client-react/prod.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "commonjs",
     "outDir": "./lib"
   },

--- a/packages/client/prod-esm.tsconfig.json
+++ b/packages/client/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/client/prod.tsconfig.json
+++ b/packages/client/prod.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "commonjs",
     "outDir": "./lib"
   },

--- a/packages/core/prod-esm.tsconfig.json
+++ b/packages/core/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/core/prod.tsconfig.json
+++ b/packages/core/prod.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "commonjs",
     "outDir": "./lib"
   },

--- a/packages/manifest-validator/prod-esm.tsconfig.json
+++ b/packages/manifest-validator/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/manifest-validator/prod.tsconfig.json
+++ b/packages/manifest-validator/prod.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "commonjs",
     "outDir": "./lib"
   },

--- a/packages/server/prod-esm.tsconfig.json
+++ b/packages/server/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/server/prod.tsconfig.json
+++ b/packages/server/prod.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "commonjs",
     "outDir": "./lib"
   },

--- a/packages/simulator/prod-esm.tsconfig.json
+++ b/packages/simulator/prod-esm.tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2022",
     "outDir": "./lib-es"
   },

--- a/packages/simulator/prod.tsconfig.json
+++ b/packages/simulator/prod.tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "commonjs",
+    "outDir": "./lib"
+  },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fixes #204

The issue was introduced when doing the refactor to improve the IDE experience https://github.com/LedgerHQ/wallet-api/pull/170

As we are re-exporting some libraries such as core in the client lib, with the root tsconfig and the baseUrl set to the root of the monorepo, the build folder would actually contain all re-exported code.