### PR TITLE
feat(server): react hooks use ref instead of memo [LIVE-8773]

### DIFF
--- a/.changeset/wet-bats-thank.md
+++ b/.changeset/wet-bats-thank.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-server": minor
+---
+
+feat(server): react hooks use ref instead of memo
+
+Add setConfig to server class

--- a/packages/server/src/WalletAPIServer.ts
+++ b/packages/server/src/WalletAPIServer.ts
@@ -1,16 +1,16 @@
 import {
   Account,
+  AppHandlers,
   Currency,
   Logger,
-  Transport,
-  RpcNode,
-  RpcRequest,
+  Permission,
   RpcError,
   RpcErrorCode,
-  AppHandlers,
-  Permission,
-  createPermissionDenied,
+  RpcNode,
+  RpcRequest,
   ServerError,
+  Transport,
+  createPermissionDenied,
 } from "@ledgerhq/wallet-api-core";
 import { BehaviorSubject, combineLatest } from "rxjs";
 import { filterAccountsForCurrencies, matchCurrencies } from "./helpers";
@@ -60,6 +60,10 @@ export class WalletAPIServer extends RpcNode<
   setAccounts(accounts: Account[]) {
     this.allAccounts$.next(accounts);
     return this;
+  }
+
+  setConfig(config: ServerConfig) {
+    this.walletContext.config = config;
   }
 
   public setHandler<K extends keyof WalletHandlers>(

--- a/packages/server/src/react.ts
+++ b/packages/server/src/react.ts
@@ -5,9 +5,9 @@ import type {
   Permission,
   Transport,
 } from "@ledgerhq/wallet-api-core";
-import { useCallback, useEffect, useMemo } from "react";
-import type { ServerConfig } from "./types";
+import { useCallback, useEffect, useRef } from "react";
 import { WalletAPIServer } from "./WalletAPIServer";
+import type { ServerConfig } from "./types";
 
 export function useWalletAPIServer({
   transport,
@@ -24,22 +24,28 @@ export function useWalletAPIServer({
   currencies: Currency[];
   permission: Permission;
 }) {
-  const server = useMemo(
-    () => new WalletAPIServer(transport, config, logger),
-    [config, logger, transport]
-  );
+  const server = useRef<WalletAPIServer>();
 
   useEffect(() => {
-    server.setPermissions(permission);
-  }, [permission, server]);
+    server.current = new WalletAPIServer(transport, config, logger);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
-    server.setCurrencies(currencies);
-  }, [currencies, server]);
+    server?.current?.setConfig(config);
+  }, [config]);
 
   useEffect(() => {
-    server.setAccounts(accounts);
-  }, [accounts, server]);
+    server?.current?.setPermissions(permission);
+  }, [permission]);
+
+  useEffect(() => {
+    server?.current?.setCurrencies(currencies);
+  }, [currencies]);
+
+  useEffect(() => {
+    server?.current?.setAccounts(accounts);
+  }, [accounts]);
 
   const onMessage = useCallback(
     (event: string) => {


### PR DESCRIPTION
We switch to using a useRef instead of the useMemo to avoid recreating the server instance whenever the config changes.

Instead we added a `setConfig` to the server class to be able to update it on an existing instance.

This should help for some cases where the server would return an empty value on some endpoints.