### PR TITLE
Add optional validator properties to CosmosTransaction

### DIFF
--- a/.changeset/many-rules-rhyme.md
+++ b/.changeset/many-rules-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add optional validator properties to CosmosTransaction

--- a/packages/core/src/families/cosmos/serializer.ts
+++ b/packages/core/src/families/cosmos/serializer.ts
@@ -9,6 +9,8 @@ export const serializeCosmosTransaction = ({
   fees,
   gas,
   memo,
+  sourceValidator,
+  validators,
 }: CosmosTransaction): RawCosmosTransaction => ({
   amount: amount.toString(),
   recipient,
@@ -17,6 +19,13 @@ export const serializeCosmosTransaction = ({
   fees: fees ? fees.toString() : undefined,
   gas: gas ? gas.toString() : undefined,
   memo,
+  sourceValidator: sourceValidator ?? undefined,
+  validators: validators
+    ? validators.map((val) => ({
+        ...val,
+        amount: val.amount.toString(),
+      }))
+    : undefined,
 });
 
 export const deserializeCosmosTransaction = ({
@@ -27,6 +36,8 @@ export const deserializeCosmosTransaction = ({
   fees,
   gas,
   memo,
+  sourceValidator,
+  validators,
 }: RawCosmosTransaction): CosmosTransaction => ({
   amount: new BigNumber(amount),
   recipient,
@@ -35,4 +46,11 @@ export const deserializeCosmosTransaction = ({
   fees: fees ? new BigNumber(fees) : undefined,
   gas: gas ? new BigNumber(gas) : undefined,
   memo,
+  sourceValidator: sourceValidator ?? undefined,
+  validators: validators
+    ? validators.map((val) => ({
+        ...val,
+        amount: new BigNumber(val.amount),
+      }))
+    : undefined,
 });

--- a/packages/core/src/families/cosmos/types.ts
+++ b/packages/core/src/families/cosmos/types.ts
@@ -8,12 +8,19 @@ import type {
 
 export type CosmosOperationMode = z.infer<typeof schemaCosmosOperationMode>;
 
+export type CosmosDelegationInfo = {
+  address: string;
+  amount: BigNumber;
+};
+
 export interface CosmosTransaction extends TransactionCommon {
   readonly family: RawCosmosTransaction["family"];
   mode: CosmosOperationMode;
   fees?: BigNumber;
   gas?: BigNumber;
   memo?: string;
+  sourceValidator?: string;
+  validators?: CosmosDelegationInfo[];
 }
 
 export type RawCosmosTransaction = z.infer<typeof schemaRawCosmosTransaction>;

--- a/packages/core/src/families/cosmos/validation.ts
+++ b/packages/core/src/families/cosmos/validation.ts
@@ -10,10 +10,17 @@ export const schemaCosmosOperationMode = z.enum([
   "claimRewardCompound",
 ]);
 
+const cosmosDelegationInfo = z.object({
+  address: z.string(),
+  amount: z.string(),
+});
+
 export const schemaRawCosmosTransaction = schemaTransactionCommon.extend({
   family: z.literal(schemaFamilies.enum.cosmos),
   mode: schemaCosmosOperationMode,
   fees: z.string().optional(),
   gas: z.string().optional(),
   memo: z.string().optional(),
+  sourceValidator: z.string().optional(),
+  validators: z.array(cosmosDelegationInfo).optional(),
 });

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -230,7 +230,7 @@ describe("serializers.ts", () => {
     describe("cosmos", () => {
       const family = schemaFamilies.enum.cosmos;
 
-      it("should succeed to serialize a cosmos transaction with fees, gas and memo", () => {
+      it("should succeed to serialize a cosmos transaction with fees, gas, memo, validators and sourceValidator", () => {
         const transaction: CosmosTransaction = {
           family,
           mode: "send",
@@ -239,6 +239,8 @@ describe("serializers.ts", () => {
           memo: "memo",
           amount: new BigNumber(100),
           recipient: "recipient",
+          validators: [{ address: "recipient", amount: new BigNumber(100) }],
+          sourceValidator: "sourceValidator",
         };
         const serializedTransaction = serializeTransaction(transaction);
 
@@ -250,10 +252,12 @@ describe("serializers.ts", () => {
           memo: "memo",
           amount: "100",
           recipient: "recipient",
+          validators: [{ address: "recipient", amount: "100" }],
+          sourceValidator: "sourceValidator",
         });
       });
 
-      it("should succeed to serialize a cosmos transaction without fees, gas and memo", () => {
+      it("should succeed to serialize a cosmos transaction without fees, gas, memo, validators and sourceValidator", () => {
         const transaction: CosmosTransaction = {
           family,
           mode: "send",
@@ -270,6 +274,8 @@ describe("serializers.ts", () => {
           memo: undefined,
           amount: "100",
           recipient: "recipient",
+          validators: undefined,
+          sourceValidator: undefined,
         });
       });
     });


### PR DESCRIPTION
### 📝 Description

Adds optional `validators` and `sourceValidator` properties to the `CosmosTransaction` interface and adjustment to the related serializer, and schema validation based on a Ledger Live Common type found in the Ledger Live monorepo [here](https://github.com/LedgerHQ/ledger-live/blob/de06c81fd976a46fa8b637cef7d284602d46b16b/libs/ledger-live-common/src/families/cosmos/types.ts#L162C25-L162C25). 

### ❓ Context

We are currently building a ledger live app for [StakeKit](https://www.stakek.it/) that offers users a unified non-custodial staking experience across a wide range of networks and protocols. We were unable to use the Wallet API to sign and broadcast Cosmos Delegate transactions. After investigating the ledger-live monorepo and modifying the CosmosTransaction interface, serializer and schema validation to match the type in the [monorepo](https://github.com/LedgerHQ/ledger-live/blob/de06c81fd976a46fa8b637cef7d284602d46b16b/libs/ledger-live-common/src/families/cosmos/types.ts#L162C25-L162C25), we were able to successfully sign the transaction using the Wallet API.

### ✅ Checklist

- [x] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes** 

### 📸 Demo

https://github.com/LedgerHQ/wallet-api/assets/22058587/59319d3e-6e81-4382-9bc8-8445bcd34351