### PR TITLE
Add enum for Near operation mode

### DIFF
--- a/.changeset/rude-kiwis-impress.md
+++ b/.changeset/rude-kiwis-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": patch
+---
+
+Add enum for Near operation mode

--- a/packages/core/src/families/near/types.ts
+++ b/packages/core/src/families/near/types.ts
@@ -1,11 +1,16 @@
 import type BigNumber from "bignumber.js";
 import type { z } from "zod";
 import type { TransactionCommon } from "../index";
-import type { schemaRawNearTransaction } from "./validation";
+import type {
+  schemaNearOperationMode,
+  schemaRawNearTransaction,
+} from "./validation";
+
+export type NearOperationMode = z.infer<typeof schemaNearOperationMode>;
 
 export type NearTransaction = TransactionCommon & {
   readonly family: RawNearTransaction["family"];
-  mode: string;
+  mode: NearOperationMode;
   fees?: BigNumber;
 };
 

--- a/packages/core/src/families/near/validation.ts
+++ b/packages/core/src/families/near/validation.ts
@@ -1,8 +1,15 @@
 import { z } from "zod";
 import { schemaFamilies, schemaTransactionCommon } from "../common";
 
+export const schemaNearOperationMode = z.enum([
+  "send",
+  "stake",
+  "unstake",
+  "withdraw",
+]);
+
 export const schemaRawNearTransaction = schemaTransactionCommon.extend({
   family: z.literal(schemaFamilies.enum.near),
-  mode: z.string(),
+  mode: schemaNearOperationMode,
   fees: z.string().optional(),
 });

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -567,6 +567,17 @@ describe("serializers.ts", () => {
           fees: "1",
         });
       });
+
+      it("should succeed to serialize a stake near transaction", () => {
+        const tx = createTx();
+        const rawTx = serializeTransaction({ ...tx, mode: "stake" });
+
+        expect(rawTx).toEqual({
+          ...tx,
+          amount: "100",
+          mode: "stake",
+        });
+      });
     });
 
     describe("neo", () => {
@@ -1457,7 +1468,7 @@ describe("serializers.ts", () => {
         const serializedTransaction = serializeTransaction(transaction);
         const stringifiedTransaction = JSON.stringify(serializedTransaction);
         const parsedTransaction = JSON.parse(
-          stringifiedTransaction
+          stringifiedTransaction,
         ) as RawTransaction;
         const expectedTransaction = deserializeTransaction(parsedTransaction);
 

--- a/spec/core/types.md
+++ b/spec/core/types.md
@@ -209,6 +209,26 @@ The raw representation of the common transaction fields found in [TransactionCom
 | `nonce?`    | `number`                                   |                                                                                                                                                                                                                 |
 | `recipient` | `string`                                   | The address of the transaction's recipient                                                                                                                                                                      |
 
+### NearTransaction
+
+| Name        | Type                                         | Description                                                                                                                                                                                                     |
+| ----------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`    | `BigNumber`                                  | The amount of token to send in the transaction, denoted in the smallest cryptocurrency's magnitude For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx corresponding to 0.00000001 BTC |
+| `family`    | [`NEAR`](/spec/core/types.md#families) |                                                                                                                                                                                                                 |
+| `fees?`     | `BigNumber`                                  |                                                                                                                                                                                                                 |
+| `mode`      | [`NearOperationMode`](/spec/core/types.md#nearoperationmode)                                     |                                                                                                                                                                                                                 |
+| `recipient` | `string`                                     | The address of the transaction's recipient                                                                                                                                                                      |
+
+### RawNearTransaction
+
+| Name        | Type                                       | Description                                                                                                                                                                                                     |
+| ----------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount`    | `string`                                   | The amount of token to send in the transaction, denoted in the smallest cryptocurrency's magnitude For example in BTC, a tx with an 'amount' field of 1 will correspond to a tx corresponding to 0.00000001 BTC |
+| `family`    | [NEAR](/spec/core/types.md#families) |                                                                                                                                                                                                                 |
+| `fees?`     | `string`                                   |                                                                                                                                                                                                                 |
+| `mode`      | `string`                                   |                                                                                                                                                                                                                 |
+| `recipient` | `string`                                   | The address of the transaction's recipient                                                                                                                                                                      |
+
 ### PolkadotTransaction
 
 | Name        | Type                                                                 | Description                                                                                                                                                                                                     |
@@ -349,6 +369,7 @@ Supported coin families
 | COSMOS     | `cosmos`     |
 | CRYPTO_ORG | `crypto_org` |
 | ETHEREUM   | `ethereum`   |
+| NEAR       | `near`       |
 | POLKADOT   | `polkadot`   |
 | RIPPLE     | `ripple`     |
 | STELLAR    | `stellar`    |
@@ -430,6 +451,11 @@ The raw representation of the [Account](/spec/core/types.md#account) type.
 ## StellarMemoType
 
 `"MEMO_TEXT"` \| `"MEMO_ID"` \| `"MEMO_HASH"` \| `"MEMO_RETURN"`
+
+## NearOperationMode
+
+`"send"` \| `"stake"` \| `"unstake"` \| `"withdraw"`
+
 
 ## ApplicationDetails
 


### PR DESCRIPTION
### 📝 Description

Adds operation mode for NearTransaction interface, and related serialization based on the logic [here](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/families/near/js-buildTransaction.ts). Also adds docs for Near.

### ❓ Context

While adding support for near staking in our ledger live app for [StakeKit](https://www.stakek.it/) we didn't easily find the correct modes to use. 

### ✅ Checklist

- [x] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes** 
