### PR TITLE
defaults results to an empty object if null or undefined

### DIFF
--- a/.changeset/rude-boxes-flash.md
+++ b/.changeset/rude-boxes-flash.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-simulator": patch
+"@ledgerhq/wallet-api-client": patch
+"@ledgerhq/wallet-api-core": patch
+---
+
+allow empty (void) values to be returned by the RPCNode requests

--- a/packages/core/src/JSONRPC/RpcNode.ts
+++ b/packages/core/src/JSONRPC/RpcNode.ts
@@ -47,7 +47,7 @@ export abstract class RpcNode<TSHandlers, TCHandlers> {
 
   private _request<K extends keyof TCHandlers>(
     request: RpcRequest<K, MethodParamsIfExists<TCHandlers, K>>,
-  ): Promise<ReturnTypeOfMethodIfExists<TCHandlers, K>> {
+  ): Promise<ReturnTypeOfMethodIfExists<TCHandlers, K> | undefined> {
     return new Promise((resolve, reject) => {
       if (!request.id) {
         reject(new Error("requests need to have an id"));
@@ -90,7 +90,7 @@ export abstract class RpcNode<TSHandlers, TCHandlers> {
   public request<K extends keyof TCHandlers>(
     method: K,
     params: MethodParamsIfExists<TCHandlers, K>,
-  ): Promise<ReturnTypeOfMethodIfExists<TCHandlers, K>> {
+  ): Promise<ReturnTypeOfMethodIfExists<TCHandlers, K> | undefined> {
     const requestId = uuidv4();
     return this._request({
       id: requestId,

--- a/packages/core/src/JSONRPC/helpers.ts
+++ b/packages/core/src/JSONRPC/helpers.ts
@@ -48,7 +48,7 @@ export function createRpcRequest<T>(
 type CreateRpcResponseParams<T, E> =
   | {
       id: string | number | null;
-      result: T;
+      result?: T;
     }
   | {
       id: string | number | null;

--- a/packages/core/src/JSONRPC/types.ts
+++ b/packages/core/src/JSONRPC/types.ts
@@ -113,7 +113,7 @@ export type RpcResponseSuccess<TResult = unknown> = RpcResponseCommon & {
    * This member **MUST NOT** exist if there was an error invoking the method.
    * The value of this member is determined by the method invoked on the Server.
    */
-  result: TResult;
+  result?: TResult;
 };
 
 export type RpcResponseFailed<TErrorData = unknown> = RpcResponseCommon & {

--- a/packages/core/src/JSONRPC/validation.ts
+++ b/packages/core/src/JSONRPC/validation.ts
@@ -23,7 +23,7 @@ export const schemaRPCResponseSuccess = z
   .object({
     jsonrpc: z.literal("2.0"),
     id: schemaRPCId,
-    result: z.object({}).passthrough(),
+    result: z.object({}).passthrough().optional(),
   })
   .strict();
 

--- a/packages/core/src/spec/types/StorageSet.ts
+++ b/packages/core/src/spec/types/StorageSet.ts
@@ -6,7 +6,7 @@ const schemaStorageSetParams = z.object({
   storeId: z.string().optional(),
 });
 
-const schemaStorageSetResults = z.void();
+const schemaStorageSetResults = z.void().optional();
 
 export const schemaStorageSet = {
   params: schemaStorageSetParams,

--- a/packages/simulator/tests/simulator.spec.ts
+++ b/packages/simulator/tests/simulator.spec.ts
@@ -244,7 +244,7 @@ describe("Simulator", () => {
       // WHEN
       const key = "testKey";
       const value = "testValue";
-      void client.storage.set(key, value); // TODO fix me when we can await
+      await client.storage.set(key, value);
       const retrievedValue = await client.storage.get(key);
 
       // THEN


### PR DESCRIPTION
[JIRA ISSUE: LIVE-9765](https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/623?selectedIssue=LIVE-9765)

bug fix video with logs, _trying out storage.set function call @ 00:26_ : 


https://github.com/LedgerHQ/wallet-api/assets/5050709/fa79a2f4-0180-4671-a61b-6115a9b22e77


One first way to solve the problem didn't end up working (@RamyEB , @Justkant), as the `params` object was as such: 

```js
{
 ...
 result: undefined,
}
```

Thus overriding the empty object we would set above.

<img width="787" alt="SCR-20231201-ozxg" src="https://github.com/LedgerHQ/wallet-api/assets/5050709/5b2f2c45-5682-4819-81f8-66d9167082ee">
