### PR TITLE
Add optional attributes to PolkadotTransaction

### DIFF
--- a/.changeset/metal-dolls-punch.md
+++ b/.changeset/metal-dolls-punch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+add optional attributes for PolkadotTransaction

--- a/packages/core/src/families/polkadot/serializer.ts
+++ b/packages/core/src/families/polkadot/serializer.ts
@@ -8,6 +8,9 @@ export const serializePolkadotTransaction = ({
   mode,
   fee,
   era,
+  validators,
+  numOfSlashingSpans,
+  rewardDestination,
 }: PolkadotTransaction): RawPolkadotTransaction => ({
   amount: amount.toString(),
   recipient,
@@ -15,6 +18,9 @@ export const serializePolkadotTransaction = ({
   mode,
   fee: fee ? fee.toString() : undefined,
   era,
+  validators,
+  numOfSlashingSpans,
+  rewardDestination,
 });
 
 export const deserializePolkadotTransaction = ({
@@ -24,6 +30,9 @@ export const deserializePolkadotTransaction = ({
   mode,
   fee,
   era,
+  validators,
+  numOfSlashingSpans,
+  rewardDestination,
 }: RawPolkadotTransaction): PolkadotTransaction => ({
   amount: new BigNumber(amount),
   recipient,
@@ -31,4 +40,7 @@ export const deserializePolkadotTransaction = ({
   mode,
   fee: fee ? new BigNumber(fee) : undefined,
   era,
+  validators,
+  numOfSlashingSpans,
+  rewardDestination,
 });

--- a/packages/core/src/families/polkadot/types.ts
+++ b/packages/core/src/families/polkadot/types.ts
@@ -1,18 +1,25 @@
-import type BigNumber from "bignumber.js";
+import BigNumber from "bignumber.js";
 import type { z } from "zod";
-import type { TransactionCommon } from "../index";
+import { TransactionCommon } from "../types";
 import type {
   schemaPolkadotOperationMode,
+  schemaPolkadotRewardDestination,
   schemaRawPolkadotTransaction,
 } from "./validation";
 
 export type PolkadotOperationMode = z.infer<typeof schemaPolkadotOperationMode>;
+export type PolkadotRewardDestination = z.infer<
+  typeof schemaPolkadotRewardDestination
+>;
 
 export type PolkadotTransaction = TransactionCommon & {
   readonly family: RawPolkadotTransaction["family"];
   mode: PolkadotOperationMode;
   fee?: BigNumber;
   era?: number;
+  validators?: string[];
+  numOfSlashingSpans?: number;
+  rewardDestination?: PolkadotRewardDestination;
 };
 
 export type RawPolkadotTransaction = z.infer<

--- a/packages/core/src/families/polkadot/validation.ts
+++ b/packages/core/src/families/polkadot/validation.ts
@@ -4,6 +4,7 @@ import { schemaFamilies, schemaTransactionCommon } from "../common";
 export const schemaPolkadotOperationMode = z.enum([
   "send",
   "bond",
+  "bondExtra",
   "unbond",
   "rebond",
   "withdrawUnbonded",
@@ -13,9 +14,20 @@ export const schemaPolkadotOperationMode = z.enum([
   "claimReward",
 ]);
 
+export const schemaPolkadotRewardDestination = z.enum([
+  "Staked",
+  "Stash",
+  "Controller",
+  "Account",
+  "None",
+]);
+
 export const schemaRawPolkadotTransaction = schemaTransactionCommon.extend({
   family: z.literal(schemaFamilies.enum.polkadot),
   mode: schemaPolkadotOperationMode,
   fee: z.string().optional(),
   era: z.number().optional(),
+  validators: z.array(z.string()).optional(),
+  rewardDestination: schemaPolkadotRewardDestination.optional(),
+  numOfSlashingSpans: z.number().optional(),
 });

--- a/packages/core/src/families/polkadot/validation.ts
+++ b/packages/core/src/families/polkadot/validation.ts
@@ -4,7 +4,6 @@ import { schemaFamilies, schemaTransactionCommon } from "../common";
 export const schemaPolkadotOperationMode = z.enum([
   "send",
   "bond",
-  "bondExtra",
   "unbond",
   "rebond",
   "withdrawUnbonded",


### PR DESCRIPTION
📝 Description
Adds optional attributes:
- `validators`
- `numOfSlashingSpans`
- `rewardDestination`

to the `PolkadotTransaction` interface and changes to the validation and serialization, based on a Ledger Live type found in the Ledger Live monorepo [here](https://github.com/LedgerHQ/ledger-live/blob/de06c81fd976a46fa8b637cef7d284602d46b16b/libs/coin-polkadot/src/types.ts#L65).

❓ Context
We are currently building a ledger live app for [StakeKit](https://www.stakek.it/) that offers users a unified non-custodial staking experience across a wide range of networks and protocols. 
Like we did for Cosmos [here](https://github.com/LedgerHQ/wallet-api/pull/220) a while back, we are now adding support to Polkadot validator staking and need this type to support and serialize all the fields needed for the different sets of calls.

✅ Checklist
- [ ]  Test coverage
- [x]  Atomic delivery
- [x]  No breaking changes