### PR TITLE
fix: WindowMessageTransport accepts same origin messages [LIVE-10439]

### DIFF
--- a/.changeset/tidy-berries-wave.md
+++ b/.changeset/tidy-berries-wave.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-core": patch
+---
+
+fix: WindowMessageTransport accepts same origin messages
+
+In order to support browserViews in electron

--- a/packages/core/src/transports/WindowMessageTransport.ts
+++ b/packages/core/src/transports/WindowMessageTransport.ts
@@ -40,11 +40,7 @@ export default class WindowMessageTransport implements Transport {
   _onMessageEvent = (event: MessageEvent): void => {
     if (this._onMessage) {
       this.logger.debug("received message event", event);
-      if (
-        event.origin !== this.target.location.origin &&
-        event.data &&
-        typeof event.data === "string"
-      ) {
+      if (event.data && typeof event.data === "string") {
         try {
           const message = event.data;
 


### PR DESCRIPTION
In order to support browserViews in electron