### PR TITLE
feat: add `tokenCurrency` to support token accounts in some handlers

### DIFF
--- a/.changeset/wet-donkeys-obey.md
+++ b/.changeset/wet-donkeys-obey.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-server": patch
+"@ledgerhq/wallet-api-core": patch
+---
+
+Allows tokenCurrency field for handlers also accepting an account id

--- a/apps/wallet-api-tools/manifest.json
+++ b/apps/wallet-api-tools/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "wallet-api-tools",
   "name": "Wallet API Tools",
-  "url": "https://wallet-api-wallet-api-tools.vercel.app",
+  "url": "http://localhost:3001",
   "homepageUrl": "https://developers.ledger.com/",
   "icon": "",
   "platform": "all",

--- a/apps/wallet-api-tools/manifest.json
+++ b/apps/wallet-api-tools/manifest.json
@@ -8,9 +8,7 @@
   "apiVersion": "^2.0.0",
   "manifestVersion": "1",
   "branch": "debug",
-  "categories": [
-    "tools"
-  ],
+  "categories": ["tools"],
   "currencies": "*",
   "content": {
     "shortDescription": {

--- a/apps/wallet-api-tools/manifest.json
+++ b/apps/wallet-api-tools/manifest.json
@@ -8,7 +8,9 @@
   "apiVersion": "^2.0.0",
   "manifestVersion": "1",
   "branch": "debug",
-  "categories": ["tools"],
+  "categories": [
+    "tools"
+  ],
   "currencies": "*",
   "content": {
     "shortDescription": {

--- a/packages/core/src/spec/types/AccountReceive.ts
+++ b/packages/core/src/spec/types/AccountReceive.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const schemaAccountReceiveParams = z.object({
   accountId: z.string(),
+  tokenCurrency: z.string().optional(),
 });
 
 const schemaAccountReceiveResults = z.object({

--- a/packages/core/src/spec/types/TransactionSign.ts
+++ b/packages/core/src/spec/types/TransactionSign.ts
@@ -10,6 +10,7 @@ const schemaTransactionSignParams = z.object({
   rawTransaction: schemaRawTransaction,
   options: schemaTransactionOptions.optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
+  tokenCurrency: z.string().optional(),
 });
 
 const schemaTransactionSignResults = z.object({

--- a/packages/core/src/spec/types/TransactionSignAndBroadcast.ts
+++ b/packages/core/src/spec/types/TransactionSignAndBroadcast.ts
@@ -10,6 +10,7 @@ const schemaTransactionSignAndBroadcastParams = z.object({
   rawTransaction: schemaRawTransaction,
   options: schemaTransactionOptions.optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
+  tokenCurrency: z.string().optional(),
 });
 
 const schemaTransactionSignAndBroadcastResults = z.object({

--- a/packages/server/src/internalHandlers/account.ts
+++ b/packages/server/src/internalHandlers/account.ts
@@ -92,7 +92,7 @@ export const receive: RPCHandler<AccountReceive["result"]> = async (
   handlers,
 ) => {
   const safeParams = schemaAccountReceive.params.parse(req.params);
-  const { accountId } = safeParams;
+  const { accountId, tokenCurrency } = safeParams;
 
   const accounts = await firstValueFrom(context.accounts$);
 
@@ -108,7 +108,7 @@ export const receive: RPCHandler<AccountReceive["result"]> = async (
     throw new ServerError(createNotImplementedByWallet("account.receive"));
   }
 
-  const result = await walletHandler({ account });
+  const result = await walletHandler({ account, tokenCurrency });
 
   return {
     address: result,

--- a/packages/server/src/internalHandlers/transaction.ts
+++ b/packages/server/src/internalHandlers/transaction.ts
@@ -20,7 +20,8 @@ export const sign: RPCHandler<TransactionSign["result"]> = async (
 
   const accounts = await firstValueFrom(context.accounts$);
 
-  const { accountId, rawTransaction, options, meta } = safeParams;
+  const { accountId, rawTransaction, options, meta, tokenCurrency } =
+    safeParams;
 
   const account = accounts.find((acc) => acc.id === accountId);
 
@@ -36,6 +37,7 @@ export const sign: RPCHandler<TransactionSign["result"]> = async (
 
   const signedTransaction = await walletHandler({
     account,
+    tokenCurrency,
     transaction: deserializeTransaction(rawTransaction),
     options,
     meta,
@@ -61,7 +63,8 @@ export const signAndBroadcast: RPCHandler<
 
   const accounts = await firstValueFrom(context.accounts$);
 
-  const { accountId, rawTransaction, options, meta } = safeParams;
+  const { accountId, rawTransaction, options, meta, tokenCurrency } =
+    safeParams;
 
   const account = accounts.find((acc) => acc.id === accountId);
 
@@ -71,6 +74,7 @@ export const signAndBroadcast: RPCHandler<
 
   const transactionHash = await walletHandler({
     account,
+    tokenCurrency,
     transaction: deserializeTransaction(rawTransaction),
     options,
     meta,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -63,23 +63,29 @@ export type WalletHandlers = {
     currencies$: Observable<Currency[]>;
     accounts$: Observable<Account[]>;
   }) => Promisable<Account>;
-  "account.receive": (params: { account: Account }) => Promisable<string>;
+  "account.receive": (params: {
+    account: Account;
+    tokenCurrency?: string;
+  }) => Promisable<string>;
   "message.sign": (params: {
     account: Account;
     message: Buffer;
     meta: Record<string, unknown> | undefined;
+    tokenCurrency?: string;
   }) => Promisable<Buffer>;
   "transaction.sign": (params: {
     account: Account;
     transaction: Transaction;
     options?: TransactionSign["params"]["options"];
     meta: Record<string, unknown> | undefined;
+    tokenCurrency?: string;
   }) => Promisable<Buffer>;
   "transaction.signAndBroadcast": (params: {
     account: Account;
     transaction: Transaction;
     options?: TransactionSignAndBroadcast["params"]["options"];
     meta: Record<string, unknown> | undefined;
+    tokenCurrency?: string;
   }) => Promisable<string>;
   "device.close": (params: DeviceClose["params"]) => Promisable<string>;
   "device.exchange": (params: DeviceExchange["params"]) => Promisable<string>;


### PR DESCRIPTION
### 📝 Description

Handle empty token accounts by using `tokenCurrency` - an (optional) parameter - for the `transaction.sign` and `transaction.signAndBroadcast` wallet api handlers. 


PR ledger live: https://github.com/LedgerHQ/ledger-live/pull/5925 

Jira issue: https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/623?selectedIssue=LIVE-10041