### PR TITLE
fix: use Map to avoid prototype-polluting assignment

### DIFF
--- a/.changeset/light-cycles-tickle.md
+++ b/.changeset/light-cycles-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-simulator": patch
+---
+
+fix: use Map to avoid prototype-polluting assignment

--- a/packages/simulator/src/profiles/standard/index.ts
+++ b/packages/simulator/src/profiles/standard/index.ts
@@ -15,7 +15,7 @@ const allCurrencies: Currency[] = rawCurrencies as Currency[];
 
 const allAccounts: Account[] = rawAccounts.map(deserializeAccount);
 
-const storage: Record<string, Record<string, string>> = {};
+const storage: Record<string, Map<string, string>> = {};
 
 export const standardProfile: SimulatorProfile = {
   config: {
@@ -66,13 +66,13 @@ export const standardProfile: SimulatorProfile = {
     "account.receive": () => "eth address",
     "storage.set": ({ value, key, storeId }) => {
       if (!storage[storeId]) {
-        storage[storeId] = {};
+        storage[storeId] = new Map();
       }
 
       const store = storage[storeId];
 
       if (store) {
-        store[key] = value;
+        store.set(key, value);
       }
     },
     "storage.get": ({ key, storeId }) => {
@@ -82,7 +82,7 @@ export const standardProfile: SimulatorProfile = {
         return undefined;
       }
 
-      return store[key];
+      return store.get(key);
     },
     "bitcoin.getXPub": () => "xpub",
     "exchange.start": ({ exchangeType }) =>


### PR DESCRIPTION
Fixes a small issue in the simulator standard profile that shouldn't affect real apps as it's only used for testing purposes
Reported by the code scanning feature of github here: https://github.com/LedgerHQ/wallet-api/security/code-scanning/1