### PR TITLE
fix: remove `@ledgerhq/hw-transport-http` that uses an old axios version

### DIFF
--- a/.changeset/lovely-boats-pay.md
+++ b/.changeset/lovely-boats-pay.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-simulator": patch
+---
+
+fix: remove `@ledgerhq/hw-transport-http` that uses an old axios version

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@ledgerhq/hw-transport": "^6.30.4",
-    "@ledgerhq/hw-transport-http": "^6.29.4",
     "@ledgerhq/wallet-api-client": "workspace:*",
     "@ledgerhq/wallet-api-core": "workspace:*",
     "@ledgerhq/wallet-api-server": "workspace:*",

--- a/packages/simulator/src/profiles/device/index.ts
+++ b/packages/simulator/src/profiles/device/index.ts
@@ -1,15 +1,10 @@
-import type HWTransport from "@ledgerhq/hw-transport";
-import TransportHttp from "@ledgerhq/hw-transport-http";
+import HWTransport from "@ledgerhq/hw-transport";
 import type { SimulatorProfile } from "../../types";
 import { standardProfile } from "../standard";
 
-export const deviceProfile: (deviceProxyUrl?: string) => SimulatorProfile = (
-  deviceProxyUrl,
-) => {
-  const httpTransport = deviceProxyUrl
-    ? TransportHttp(deviceProxyUrl.split("|"))
-    : undefined;
-
+export const deviceProfile: (
+  mainTransport: typeof HWTransport,
+) => SimulatorProfile = (mainTransport) => {
   let transport: HWTransport | undefined;
 
   return {
@@ -28,24 +23,18 @@ export const deviceProfile: (deviceProxyUrl?: string) => SimulatorProfile = (
     methods: {
       ...standardProfile.methods,
       "device.transport": async () => {
-        if (!httpTransport) {
-          throw new Error("Proxy not setup");
-        }
         if (transport) {
           throw new Error("Transport already opened");
         }
-        transport = await httpTransport.create(3000, 5000);
+        transport = await mainTransport.create(3000, 5000);
         return "1";
       },
       "device.select": () => "",
       "device.open": async () => {
-        if (!httpTransport) {
-          throw new Error("Proxy not setup");
-        }
         if (transport) {
           throw new Error("Transport already opened");
         }
-        transport = await httpTransport.create(3000, 5000);
+        transport = await mainTransport.create(3000, 5000);
         return "1";
       },
       "device.exchange": async ({ apduHex, transportId }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,9 +528,6 @@ importers:
       '@ledgerhq/hw-transport':
         specifier: ^6.30.4
         version: 6.30.4
-      '@ledgerhq/hw-transport-http':
-        specifier: ^6.29.4
-        version: 6.29.4
       '@ledgerhq/wallet-api-client':
         specifier: workspace:*
         version: link:../client
@@ -1828,20 +1825,6 @@ packages:
 
   /@ledgerhq/errors@6.16.2:
     resolution: {integrity: sha512-jFpohaSW+p1Obp3NDT9QSByEtT3gtBZIjVNu8m25gnrH5zdtfPVlPwH6UiuS50s+2dHQyehV8hF+IfreKDWAZA==}
-    dev: false
-
-  /@ledgerhq/hw-transport-http@6.29.4:
-    resolution: {integrity: sha512-pYcaS5BtIehdVGktOTUo7V4CX0Se+Kqm53PC3uJMNOvlNvTQ5rpfr///+k4mky3uVXM25Q7W8svqYe8/x74swQ==}
-    dependencies:
-      '@ledgerhq/errors': 6.16.2
-      '@ledgerhq/hw-transport': 6.30.4
-      '@ledgerhq/logs': 6.12.0
-      axios: 0.26.1
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
     dev: false
 
   /@ledgerhq/hw-transport@6.30.4:
@@ -3890,14 +3873,6 @@ packages:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
 
-  /axios@0.26.1:
-    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
-    dependencies:
-      follow-redirects: 1.15.5
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
     dependencies:
@@ -5743,16 +5718,6 @@ packages:
 
   /focus-visible@5.2.0:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
-    dev: false
-
-  /follow-redirects@1.15.5:
-    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: false
 
   /for-each@0.3.3:
@@ -10707,19 +10672,6 @@ packages:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
     dev: true
-
-  /ws@7.5.9:
-    resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
 
   /ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}


### PR DESCRIPTION
Removed the need for us to have a dependency on `@ledgerhq/hw-transport-http` in order to remove the old axios dependency
Reported by github dependabot alerts: https://github.com/LedgerHQ/wallet-api/security/dependabot/3