### PR TITLE
fix: loosen family validation to provide better forward compatibility [LIVE-12433]

### DIFF
--- a/.changeset/light-points-love.md
+++ b/.changeset/light-points-love.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": patch
+---
+
+fix: loosen family validation to provide better forward compatibility

--- a/packages/core/src/currencies/validation.ts
+++ b/packages/core/src/currencies/validation.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { schemaFamilies } from "../families/common";
 
 export const schemaCurrencyType = z.enum(["CryptoCurrency", "TokenCurrency"]);
 export const schemaTokenStandard = z.enum(["ERC20"]);
@@ -14,7 +13,7 @@ export const schemaBaseCurrency = z.object({
 
 export const schemaCryptoCurrency = schemaBaseCurrency.extend({
   type: z.literal(schemaCurrencyType.enum.CryptoCurrency),
-  family: schemaFamilies,
+  family: z.string(),
 });
 
 export const schemaTokenCurrency = schemaBaseCurrency.extend({


### PR DESCRIPTION
This change allows live-app using an old version of the wallet-api to work on new versions of LL introducing new families