### PR TITLE
feat: add client prop to the react provider

### DIFF
--- a/.changeset/three-numbers-pretend.md
+++ b/.changeset/three-numbers-pretend.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-client-react": minor
+---
+
+feat: add client prop to the react provider
+
+Allows to pass a user created client instead of creating it in the provider

--- a/packages/client-react/src/components/WalletAPIProvider/index.tsx
+++ b/packages/client-react/src/components/WalletAPIProvider/index.tsx
@@ -15,6 +15,7 @@ export function WalletAPIProvider({
   logger,
   getCustomModule,
   eventHandlers,
+  client: providedClient,
 }: WalletAPIProviderProps) {
   const [state, setState] = useState<WalletAPIProviderContextState>(
     initialContextValue.state,
@@ -23,12 +24,9 @@ export function WalletAPIProvider({
   const client = useRef<WalletAPIClient>();
 
   if (client.current === undefined) {
-    client.current = new WalletAPIClient(
-      transport,
-      logger,
-      getCustomModule,
-      eventHandlers,
-    );
+    client.current = providedClient
+      ? providedClient
+      : new WalletAPIClient(transport, logger, getCustomModule, eventHandlers);
   }
 
   useEffect(() => {

--- a/packages/client-react/src/components/WalletAPIProvider/types.ts
+++ b/packages/client-react/src/components/WalletAPIProvider/types.ts
@@ -17,12 +17,22 @@ export type Loadable<T> = {
   value: T | null;
 };
 
-export type WalletAPIProviderProps = PropsWithChildren<{
-  transport: Transport;
-  logger?: Logger;
-  getCustomModule?: AnyCustomGetter;
-  eventHandlers?: EventHandlers;
-}>;
+export type WalletAPIProviderProps = PropsWithChildren<
+  | {
+      transport: Transport;
+      logger?: Logger;
+      getCustomModule?: AnyCustomGetter;
+      eventHandlers?: EventHandlers;
+      client?: never;
+    }
+  | {
+      transport?: never;
+      logger?: never;
+      getCustomModule?: never;
+      eventHandlers?: never;
+      client: WalletAPIClient;
+    }
+>;
 
 export type WalletAPIProviderContextState = {
   accounts: Loadable<Account[]>;


### PR DESCRIPTION
Allows to pass a user created client instead of creating it in the provider