### PR TITLE
feat: add drawerConfiguration to account request

### DIFF
--- a/.changeset/nasty-rockets-lick.md
+++ b/.changeset/nasty-rockets-lick.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-client": minor
+"@ledgerhq/wallet-api-server": minor
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add drawerConfiguration to be able to customize MAD

--- a/apps/wallet-api-tools/src/CommandSelector/index.tsx
+++ b/apps/wallet-api-tools/src/CommandSelector/index.tsx
@@ -22,6 +22,17 @@ const data: Group[] = [
           method: "account.request",
           params: {
             currencyIds: ["ethereum", "bitcoin"],
+            drawerConfiguration: {
+              assets: {
+                filter: "topNetworks",
+                leftElement: "apy",
+                rightElement: "marketTrend",
+              },
+              networks: {
+                leftElement: "numberOfAccountsAndApy",
+                rightElement: "balance",
+              },
+            },
           },
         },
       },

--- a/packages/client/src/modules/Account.ts
+++ b/packages/client/src/modules/Account.ts
@@ -56,10 +56,22 @@ export class AccountModule {
      */
     currencyIds?: string[];
     showAccountFilter?: boolean;
+    drawerConfiguration?: {
+      assets?: {
+        filter?: string;
+        leftElement?: string;
+        rightElement?: string;
+      };
+      networks?: {
+        leftElement?: string;
+        rightElement?: string;
+      };
+    };
   }): Promise<Account> {
     const requestAccountsResult = await this.client.request("account.request", {
       currencyIds: params?.currencyIds,
       showAccountFilter: params?.showAccountFilter,
+      drawerConfiguration: params?.drawerConfiguration,
     });
 
     const safeResults = schemaAccountRequest.result.parse(

--- a/packages/core/src/spec/types/AccountRequest.ts
+++ b/packages/core/src/spec/types/AccountRequest.ts
@@ -4,6 +4,23 @@ import { schemaRawAccount } from "../../accounts";
 const schemaAccountRequestParams = z.object({
   currencyIds: z.array(z.string()).optional(),
   showAccountFilter: z.boolean().optional(),
+  drawerConfiguration: z
+    .object({
+      assets: z
+        .object({
+          filter: z.string().optional(),
+          leftElement: z.string().optional(),
+          rightElement: z.string().optional(),
+        })
+        .optional(),
+      networks: z
+        .object({
+          leftElement: z.string().optional(),
+          rightElement: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 const schemaAccountRequestResults = z.object({

--- a/packages/server/src/internalHandlers/account.ts
+++ b/packages/server/src/internalHandlers/account.ts
@@ -36,7 +36,7 @@ export const request: RPCHandler<AccountRequest["result"]> = async (
 ) => {
   const safeParams = schemaAccountRequest.params.parse(req.params);
 
-  const { currencyIds, showAccountFilter } = safeParams;
+  const { currencyIds, showAccountFilter, drawerConfiguration } = safeParams;
 
   const walletHandler = handlers["account.request"];
 
@@ -62,6 +62,7 @@ export const request: RPCHandler<AccountRequest["result"]> = async (
     currencies$: filteredCurrencies$,
     accounts$: filteredAccounts$,
     showAccountFilter,
+    drawerConfiguration,
   });
 
   return {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -66,6 +66,17 @@ export type WalletHandlers = {
     currencies$: Observable<Currency[]>;
     accounts$: Observable<Account[]>;
     showAccountFilter?: boolean;
+    drawerConfiguration?: {
+      assets?: {
+        filter?: string;
+        leftElement?: string;
+        rightElement?: string;
+      };
+      networks?: {
+        leftElement?: string;
+        rightElement?: string;
+      };
+    };
   }) => Promisable<Account>;
   "account.receive": (params: {
     account: Account;

--- a/packages/simulator/tests/simulator.spec.ts
+++ b/packages/simulator/tests/simulator.spec.ts
@@ -240,6 +240,31 @@ describe("Simulator", () => {
         client.account.request({ currencyIds: ["bitcoin"] }),
       ).rejects.toThrow("permission");
     });
+
+    it("should return the requested account with drawer configuration", async () => {
+      // GIVEN
+      const transport = getSimulatorTransport(profiles.STANDARD);
+      const client = new WalletAPIClient(transport);
+
+      // WHEN
+      const account = await client.account.request({
+        currencyIds: ["bitcoin"],
+        drawerConfiguration: {
+          assets: {
+            filter: "topNetworks",
+            leftElement: "apy",
+            rightElement: "marketTrend",
+          },
+          networks: {
+            leftElement: "numberOfAccountsAndApy",
+            rightElement: "balance",
+          },
+        },
+      });
+
+      // THEN
+      expect(account).toBeDefined();
+    });
   });
 
   describe("account.receive", () => {


### PR DESCRIPTION
To make the modular asset drawer customizable we need to pass some configuration when account.request is triggered. 

It follows this structure : 
![image](https://github.com/user-attachments/assets/b9c8abef-f68b-46af-a48b-0fa91558a09b)

We are using a general string type for those parameters instead of string literals. This is done to avoid having a dependency on wallet API if we extend those parameters to support additional values as explained [here](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/5745082390/Modularization+Parameter?focusedCommentId=5755174932).

Context : [LIVE-18776](https://ledgerhq.atlassian.net/browse/LIVE-18776)

[LIVE-18776]: https://ledgerhq.atlassian.net/browse/LIVE-18776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ