### PR TITLE
add(core/types/Device): "apex" device type

### DIFF
--- a/.changeset/ten-apricots-smash.md
+++ b/.changeset/ten-apricots-smash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": patch
+---
+
+Add "apex" to device type

--- a/packages/core/src/spec/types/Device.ts
+++ b/packages/core/src/spec/types/Device.ts
@@ -7,6 +7,7 @@ export const schemaDeviceType = z.enum([
   "nanoX",
   "stax",
   "europa",
+  "apex",
 ]);
 
 export type DeviceType = z.infer<typeof schemaDeviceType>;


### PR DESCRIPTION
I need to add apex in the device type in order to be aligned in LL.

Otherwise I get this error in LL:
```
│ src/wallet-api/react.ts:648:48 - error TS2345: Argument of type 'DeviceModelId' is not assignable to parameter of type '"blue" | "nanoS" | "nanoX" | "nanoSP" | "stax" | "europa"'.
│ 
│ 648               if (devices && !devices.includes(deviceParam.modelId)) {
```