### PR TITLE
docs: add Node.js polyfills setup instructions for Vite and Webpack [LIVE-19144]

### DIFF
--- a/apps/docs/pages/docs/discover/wallet-api/core/getting-started.mdx
+++ b/apps/docs/pages/docs/discover/wallet-api/core/getting-started.mdx
@@ -16,6 +16,61 @@ You can use your favorite package manager, to install the `@ledgerhq/wallet-api-
 npm install @ledgerhq/wallet-api-client
 ```
 
+## Node.js Polyfills Setup
+
+### Why do you need polyfills?
+
+Modern bundlers like Vite and Webpack 5+ no longer include Node.js polyfills by default. Since Ledger's Wallet API uses Node.js modules like `Buffer` for cryptographic operations, you'll need to add these polyfills manually when building for the browser.
+
+### Setting up with Vite
+
+If you're using Vite, install the `vite-plugin-node-polyfills` plugin:
+
+```sh npm2yarn
+npm install --save-dev vite-plugin-node-polyfills
+```
+
+Then add it to your `vite.config.js` or `vite.config.ts`:
+
+```js
+import { defineConfig } from "vite";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
+
+export default defineConfig({
+  plugins: [
+    nodePolyfills({
+      // Whether to polyfill `node:` protocol imports.
+      protocolImports: true,
+    }),
+  ],
+});
+```
+
+### Setting up with Webpack 5+
+
+For Webpack 5+, you can add polyfills to your `webpack.config.js`:
+
+```js
+module.exports = {
+  resolve: {
+    fallback: {
+      buffer: require.resolve("buffer"),
+    },
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
+    }),
+  ],
+};
+```
+
+You'll also need to install the polyfill package:
+
+```sh npm2yarn
+npm install buffer
+```
+
 ---
 
 Now that you've successfully installed the necessary packages, you're ready to start crafting with Ledger's Wallet

--- a/apps/docs/pages/docs/discover/wallet-api/react/getting-started.mdx
+++ b/apps/docs/pages/docs/discover/wallet-api/react/getting-started.mdx
@@ -39,6 +39,61 @@ npm install @ledgerhq/wallet-api-simulator
 Remember, this package currently only functions with server-side applications due to a dependency requiring the usage
 of `process`.
 
+## Node.js Polyfills Setup
+
+### Why do you need polyfills?
+
+Modern bundlers like Vite and Webpack 5+ no longer include Node.js polyfills by default. Since Ledger's Wallet API uses Node.js modules like `Buffer` for cryptographic operations, you'll need to add these polyfills manually when building for the browser.
+
+### Setting up with Vite
+
+If you're using Vite, install the `vite-plugin-node-polyfills` plugin:
+
+```sh npm2yarn
+npm install --save-dev vite-plugin-node-polyfills
+```
+
+Then add it to your `vite.config.js` or `vite.config.ts`:
+
+```js
+import { defineConfig } from "vite";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
+
+export default defineConfig({
+  plugins: [
+    nodePolyfills({
+      // Whether to polyfill `node:` protocol imports.
+      protocolImports: true,
+    }),
+  ],
+});
+```
+
+### Setting up with Webpack 5+
+
+For Webpack 5+, you can add polyfills to your `webpack.config.js`:
+
+```js
+module.exports = {
+  resolve: {
+    fallback: {
+      buffer: require.resolve("buffer"),
+    },
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
+    }),
+  ],
+};
+```
+
+You'll also need to install the polyfill package:
+
+```sh npm2yarn
+npm install buffer
+```
+
 ---
 
 Now that you've successfully installed the necessary packages, you're ready to start crafting with Ledger's Wallet


### PR DESCRIPTION
This pull request updates the documentation for Ledger's Wallet API to include detailed instructions on setting up Node.js polyfills for modern bundlers like Vite and Webpack 5+. These changes address the removal of default Node.js polyfills in modern bundlers and ensure compatibility with browser-based environments.

### Documentation Updates for Node.js Polyfills:

* **Added Node.js polyfills setup section for Vite**:
  - Instructions for installing and configuring the `vite-plugin-node-polyfills` plugin in `vite.config.js` or `vite.config.ts`. [[1]](diffhunk://#diff-fe3d92e595862fde6dc126a93bf0ba661673a5692edf0c386cd6e6258ac42667R19-R73) [[2]](diffhunk://#diff-a78552b7ba7b5fff7d8b2297ee50b8f2e84bb1499047a2b7b8af3111fb48274aR42-R96)

* **Added Node.js polyfills setup section for Webpack 5+**:
  - Instructions for adding `Buffer` polyfills using `webpack.ProvidePlugin` and configuring `webpack.config.js`. [[1]](diffhunk://#diff-fe3d92e595862fde6dc126a93bf0ba661673a5692edf0c386cd6e6258ac42667R19-R73) [[2]](diffhunk://#diff-a78552b7ba7b5fff7d8b2297ee50b8f2e84bb1499047a2b7b8af3111fb48274aR42-R96)

These updates are included in the "Getting Started" guides for both the Core and React sections of the Wallet API documentation.