### PR TITLE
feat(client): add signRaw method for signing raw transactions

### DIFF
--- a/.changeset/strong-pans-argue.md
+++ b/.changeset/strong-pans-argue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-client": minor
+---
+
+feat(client): add signRaw method for signing raw transaction

--- a/packages/client/src/modules/Transaction.ts
+++ b/packages/client/src/modules/Transaction.ts
@@ -1,10 +1,12 @@
 import {
   schemaTransactionSign,
   schemaTransactionSignAndBroadcast,
+  schemaTransactionSignRaw,
   serializeTransaction,
   Transaction,
   TransactionSign,
   TransactionSignAndBroadcast,
+  TransactionSignRaw,
 } from "@ledgerhq/wallet-api-core";
 import type { WalletAPIClient } from "../WalletAPIClient";
 
@@ -45,6 +47,41 @@ export class TransactionModule {
     );
 
     return Buffer.from(safeResults.signedTransactionHex, "hex");
+  }
+
+  /**
+   * Let the user sign a raw transaction that can be broadcasted by the connected wallet
+   * @param accountId - id of the account
+   * @param transaction - The raw transaction string in the currency family-specific format
+   * @param broadcast - Optional boolean to indicate if the transaction should be broadcasted by the wallet
+   * @param options - Extra parameters
+   *
+   * @returns The raw signed transaction
+   * @throws {@link RpcError} if an error occurred on server side
+   */
+  async signRaw(
+    accountId: string,
+    transaction: string,
+    broadcast?: boolean,
+    options?: TransactionSignRaw["params"]["options"],
+    meta?: Record<string, unknown>,
+  ): Promise<{ signedTransactionHex: string; transactionHash?: string }> {
+    const transactionSignRawResult = await this.client.request(
+      "transaction.signRaw",
+      {
+        accountId,
+        rawTransaction: transaction,
+        broadcast,
+        options,
+        meta,
+      },
+    );
+
+    const safeResults = schemaTransactionSignRaw.result.parse(
+      transactionSignRawResult,
+    );
+
+    return safeResults;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a new capability to the Wallet API client, allowing users to sign raw transactions using the connected wallet. The main change is the addition of the `signRaw` method to the `TransactionModule`, which enables signing and optionally broadcasting raw transactions in a currency-specific format.

**New Feature: Raw Transaction Signing**

* Added a new `signRaw` method to the `TransactionModule` in `packages/client/src/modules/Transaction.ts`, allowing users to sign and optionally broadcast raw transactions. This method accepts an account ID, a raw transaction string, and optional parameters, returning the signed transaction hex and an optional transaction hash.
* Imported the necessary types and schemas (`schemaTransactionSignRaw`, `TransactionSignRaw`) from `@ledgerhq/wallet-api-core` to support the new method.
* Documented the new feature in the changeset file `.changeset/strong-pans-argue.md`, indicating a minor version bump for `@ledgerhq/wallet-api-client`.