### PR TITLE
chore: align Tron types with Ledger Wallet

### DIFF
--- a/.changeset/eight-moles-occur.md
+++ b/.changeset/eight-moles-occur.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": patch
+---
+
+chore: align Tron types with Ledger Wallet

--- a/packages/core/src/families/tron/types.ts
+++ b/packages/core/src/families/tron/types.ts
@@ -17,7 +17,7 @@ export type TronTransaction = TransactionCommon & {
   mode: TronOperationMode;
   resource?: TronResource;
   duration?: number;
-  votes?: TronVote[];
+  votes: TronVote[];
 };
 
 export type RawTronTransaction = z.infer<typeof schemaRawTronTransaction>;

--- a/packages/core/src/families/tron/validation.ts
+++ b/packages/core/src/families/tron/validation.ts
@@ -24,5 +24,5 @@ export const schemaRawTronTransaction = schemaTransactionCommon.extend({
   mode: schemaTronOperationMode,
   resource: schemaTronResource.optional(),
   duration: z.number().optional(),
-  votes: z.array(schemaTronVotes).optional(),
+  votes: z.array(schemaTronVotes).default([]),
 });

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -48,6 +48,7 @@ import {
   RawVechainTransaction,
   RawHederaTransaction,
   HederaTransaction,
+  schemaRawTransaction,
 } from "../src";
 
 const date = new Date();
@@ -633,6 +634,7 @@ describe("serializers.ts", () => {
           duration: 5,
           amount: new BigNumber(100),
           recipient: "recipient",
+          votes: [],
         };
         const serializedTransaction = serializeTransaction(transaction);
 
@@ -643,6 +645,7 @@ describe("serializers.ts", () => {
           duration: 5,
           amount: "100",
           recipient: "recipient",
+          votes: [],
         });
       });
 
@@ -652,6 +655,7 @@ describe("serializers.ts", () => {
           mode: "send",
           amount: new BigNumber(100),
           recipient: "recipient",
+          votes: [],
         };
         const serializedTransaction = serializeTransaction(transaction);
 
@@ -662,6 +666,7 @@ describe("serializers.ts", () => {
           duration: undefined,
           amount: "100",
           recipient: "recipient",
+          votes: [],
         });
       });
 
@@ -676,6 +681,7 @@ describe("serializers.ts", () => {
             { address: "recipient2", voteCount: 50 },
           ],
         };
+
         const serializedTransaction = serializeTransaction(transaction);
 
         expect(serializedTransaction).toEqual({
@@ -1563,6 +1569,7 @@ describe("serializers.ts", () => {
           duration: 5,
           amount: "100",
           recipient: "recipient",
+          votes: [],
         };
 
         const transaction = deserializeTransaction(serializedTransaction);
@@ -1574,6 +1581,7 @@ describe("serializers.ts", () => {
           duration: 5,
           amount: new BigNumber(100),
           recipient: "recipient",
+          votes: [],
         });
       });
 
@@ -1583,6 +1591,7 @@ describe("serializers.ts", () => {
           mode: "send",
           amount: "100",
           recipient: "recipient",
+          votes: [],
         };
 
         const transaction = deserializeTransaction(serializedTransaction);
@@ -1594,6 +1603,52 @@ describe("serializers.ts", () => {
           duration: undefined,
           amount: new BigNumber(100),
           recipient: "recipient",
+          votes: [],
+        });
+      });
+
+      it("should default missing votes to [] when parsing a raw tron transaction", () => {
+        const parsed = schemaRawTransaction.parse({
+          family,
+          mode: "send",
+          amount: "100",
+          recipient: "recipient",
+        });
+
+        expect(parsed).toEqual({
+          family,
+          mode: "send",
+          amount: "100",
+          recipient: "recipient",
+          votes: [],
+        });
+      });
+
+      it("should succeed to deserialize a tron transaction with votes", () => {
+        const serializedTransaction: RawTronTransaction = {
+          family,
+          mode: "vote",
+          amount: "100",
+          recipient: "recipient",
+          votes: [
+            { address: "recipient", voteCount: 50 },
+            { address: "recipient2", voteCount: 50 },
+          ],
+        };
+
+        const transaction = deserializeTransaction(serializedTransaction);
+
+        expect(transaction).toEqual({
+          family,
+          mode: "vote",
+          resource: undefined,
+          duration: undefined,
+          amount: new BigNumber(100),
+          recipient: "recipient",
+          votes: [
+            { address: "recipient", voteCount: 50 },
+            { address: "recipient2", voteCount: 50 },
+          ],
         });
       });
     });


### PR DESCRIPTION
This PR aligns the Tron transaction `votes` property with Ledger Wallet, making it mandatory. The exposed HTTP API is not breaking though, as a missing `votes` property does fallback to an empty array (`[]`) instead via Zod.