### PR TITLE
feat: add allowManager to device connection params [LIVE-28359]

### DIFF
--- a/.changeset/allow-manager-device-connection.md
+++ b/.changeset/allow-manager-device-connection.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add optional `allowManager` support to `device.transport` and `device.select` request params so hosts can handle manager permission during device connection.

--- a/packages/core/src/spec/types/DeviceSelect.ts
+++ b/packages/core/src/spec/types/DeviceSelect.ts
@@ -5,6 +5,11 @@ const schemaDeviceSelectParams = z.object({
   /** Select the BOLOS App. If undefined selects BOLOS */
   appName: z.string().optional(),
   /**
+   * Requests host-managed manager permission when selecting the device.
+   * If undefined, preserves the host's current behavior.
+   */
+  allowManager: z.boolean().optional(),
+  /**
    * Checks the BOLOS App version range. If undefined no checks
    * Can be any ranges supported here: https://github.com/npm/node-semver#ranges
    */

--- a/packages/core/src/spec/types/DeviceTransport.ts
+++ b/packages/core/src/spec/types/DeviceTransport.ts
@@ -5,6 +5,11 @@ const schemaDeviceTransportParams = z.object({
   /** Select the BOLOS App. If undefined selects BOLOS */
   appName: z.string().optional(),
   /**
+   * Requests host-managed manager permission when connecting the device.
+   * If undefined, preserves the host's current behavior.
+   */
+  allowManager: z.boolean().optional(),
+  /**
    * Checks the BOLOS App version range. If undefined no checks
    * Can be any ranges supported here: https://github.com/npm/node-semver#ranges
    */


### PR DESCRIPTION
Add optional `allowManager` support to `device.transport` and `device.select` so hosts can receive the manager permission request during device connection.