### PR TITLE
chore(deps): bump ajv 8.20 and ajv-formats 3 in manifest-validator

### DIFF
--- a/.changeset/update-manifest-validator-ajv.md
+++ b/.changeset/update-manifest-validator-ajv.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-manifest-validator": patch
+---
+
+chore(deps): bump ajv to 8.20 and ajv-formats to 3

--- a/packages/manifest-validator/package.json
+++ b/packages/manifest-validator/package.json
@@ -36,8 +36,8 @@
     "@ledgerhq/types-cryptoassets": "^7.37.0",
     "@ledgerhq/types-devices": "^6.31.0",
     "@ledgerhq/wallet-api-core": "workspace:*",
-    "ajv": "^8.12.0",
+    "ajv": "^8.20.0",
     "ajv-errors": "^3.0.0",
-    "ajv-formats": "^2.1.1"
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,14 +458,14 @@ importers:
         specifier: workspace:*
         version: link:../core
       ajv:
-        specifier: ^8.12.0
-        version: 8.12.0
+        specifier: ^8.20.0
+        version: 8.20.0
       ajv-errors:
         specifier: ^3.0.0
-        version: 3.0.0(ajv@8.12.0)
+        version: 3.0.0(ajv@8.20.0)
       ajv-formats:
-        specifier: ^2.1.1
-        version: 2.1.1(ajv@8.12.0)
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
     devDependencies:
       '@ledgerhq/jest-shared-config':
         specifier: workspace:*
@@ -2741,8 +2741,8 @@ packages:
     peerDependencies:
       ajv: ^8.0.1
 
-  ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -2752,8 +2752,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4075,6 +4075,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -10054,13 +10057,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ajv-errors@3.0.0(ajv@8.12.0):
+  ajv-errors@3.0.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.20.0
 
-  ajv-formats@2.1.1(ajv@8.12.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.12.0
+      ajv: 8.20.0
 
   ajv@6.12.6:
     dependencies:
@@ -10069,12 +10072,12 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.12.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
 
@@ -11878,6 +11881,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.15.0:
     dependencies:


### PR DESCRIPTION
## What
`@ledgerhq/wallet-api-manifest-validator` (published) — Batch 4.

- `ajv` 8.12 → **8.20** (in-range)
- `ajv-formats` 2 → **3** (breaking) — verified `addFormats(ajv)` + `format: "uri"` behavior unchanged; `ajv-errors` stays compatible

Includes a **changeset**.

## Verified
- `pnpm --filter @ledgerhq/wallet-api-manifest-validator test` (fixtures + error reporting)
- CLI run against a sample manifest

## Notes
- Rebased onto `main` after #543 — clean auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)