### PR TITLE
feat(core): add optional publicKey field to Account

### DIFF
--- a/.changeset/account-pubkey.md
+++ b/.changeset/account-pubkey.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add an optional `publicKey` field to `Account` (type, schema, serializer), exposing an account's public key for account-based families that have one. Enables dApp flows that need the public key up front.

--- a/packages/core/src/accounts/serializers.ts
+++ b/packages/core/src/accounts/serializers.ts
@@ -19,6 +19,7 @@ export function serializeAccount({
   blockHeight,
   lastSyncDate,
   parentAccountId,
+  publicKey,
 }: Account): RawAccount {
   return {
     id,
@@ -30,6 +31,7 @@ export function serializeAccount({
     blockHeight,
     lastSyncDate: lastSyncDate.toISOString(),
     parentAccountId,
+    publicKey,
   };
 }
 
@@ -50,6 +52,7 @@ export function deserializeAccount({
   blockHeight,
   lastSyncDate,
   parentAccountId,
+  publicKey,
 }: RawAccount): Account {
   return {
     id,
@@ -61,5 +64,6 @@ export function deserializeAccount({
     blockHeight,
     lastSyncDate: new Date(lastSyncDate),
     parentAccountId,
+    publicKey,
   };
 }

--- a/packages/core/src/accounts/types.ts
+++ b/packages/core/src/accounts/types.ts
@@ -45,6 +45,14 @@ export type Account = {
   lastSyncDate: Date;
 
   parentAccountId?: string;
+
+  /**
+   * The account's public key, in the family's canonical string encoding. Only present for
+   * account-based families that expose a public key distinct from the address; absent where
+   * it is not derivable from the account (e.g. UTXO families). Some dApp flows that need the
+   * public key up front rely on this field.
+   */
+  publicKey?: string;
 };
 
 /**

--- a/packages/core/src/accounts/validation.ts
+++ b/packages/core/src/accounts/validation.ts
@@ -10,4 +10,5 @@ export const schemaRawAccount = z.object({
   blockHeight: z.union([z.number(), z.undefined()]),
   lastSyncDate: z.string(),
   parentAccountId: z.string().optional(),
+  publicKey: z.string().optional(),
 });

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -77,6 +77,22 @@ describe("serializers.ts", () => {
         lastSyncDate: date.toISOString(),
       });
     });
+
+    it("should serialize the optional publicKey when present", () => {
+      const serializedAccount = serializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: new BigNumber(0),
+        spendableBalance: new BigNumber(0),
+        blockHeight: 0,
+        lastSyncDate: date,
+        publicKey: "a-public-key",
+      });
+
+      expect(serializedAccount.publicKey).toBe("a-public-key");
+    });
   });
 
   describe("deserializeAccount", () => {
@@ -102,6 +118,22 @@ describe("serializers.ts", () => {
         blockHeight: 0,
         lastSyncDate: date,
       });
+    });
+
+    it("should deserialize the optional publicKey when present", () => {
+      const deserializedAccount = deserializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: "0",
+        spendableBalance: "0",
+        blockHeight: 0,
+        lastSyncDate: date.toISOString(),
+        publicKey: "a-public-key",
+      });
+
+      expect(deserializedAccount.publicKey).toBe("a-public-key");
     });
   });
 


### PR DESCRIPTION
Add an optional `publicKey` field to the wallet-api-core `Account` type, letting account-based families expose a public key distinct from the address over the Wallet API — needed by dApp flows that require it up front (e.g. Tezos `tezos_getAccounts`). Kept generic in this shared package; populated per-family by the consumer (ledger-live).

- Add `publicKey?: string` to `Account` and `publicKey` to `schemaRawAccount`
- Thread it through `serializeAccount` / `deserializeAccount`
- Cover both serialize and deserialize directions in tests

Optional field on a non-strict schema, so it is backward-compatible across version skew (older peers strip it; newer peers treat it as optional).

JIRA ticket: [LIVE-32115](https://ledgerhq.atlassian.net/browse/LIVE-32115)


[LIVE-32115]: https://ledgerhq.atlassian.net/browse/LIVE-32115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ