### PR TITLE
feat(ci): open a ledger-live PR when wallet-api packages are published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,19 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push version bump commit & tags
+      pull-requests: write # open the changesets "Version Packages" PR
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -31,3 +40,104 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
+  # When wallet-api packages are published, open (or replace) a PR on ledger-live that bumps
+  # those packages. Uses a fixed branch so a newer publish overwrites the still-open PR.
+  update-ledger-live:
+    name: Update wallet-api on ledger-live
+    needs: release
+    if: ${{ needs.release.outputs.published == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔑 Generate GitHub App token (ledger-live)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: LedgerHQ
+          repositories: ledger-live
+
+      - name: 📋 Checkout ledger-live
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: LedgerHQ/ledger-live
+          token: ${{ steps.app-token.outputs.token }}
+          ref: develop
+          path: ledger-live
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: ledger-live/package.json
+          run_install: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ledger-live/.nvmrc
+          cache: pnpm
+          cache-dependency-path: ledger-live/pnpm-lock.yaml
+
+      - name: ⬆️ Bump wallet-api packages
+        id: bump
+        working-directory: ledger-live
+        env:
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
+        run: |
+          # "name@version" for every published @ledgerhq/wallet-api-* package.
+          mapfile -t specs < <(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name | startswith("@ledgerhq/wallet-api-")) | "\(.name)@\(.version)"')
+          if [[ ${#specs[@]} -eq 0 ]]; then
+            echo "No wallet-api packages in this release — nothing to bump."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Bump the ^ range of each package in every consuming package.json.
+          for spec in "${specs[@]}"; do
+            name="${spec%@*}"; version="${spec##*@}"
+            echo "📦 ${name} -> ^${version}"
+            while IFS= read -r f; do
+              sed -i -E "s#(\"${name}\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")#\1^${version}\2#" "$f"
+            done < <(grep -rl --include=package.json "\"${name}\"[[:space:]]*:" . | grep -v node_modules)
+          done
+
+          # Refresh the lockfile. Retry to absorb npm registry propagation right after publish.
+          for attempt in 1 2 3 4 5; do
+            if pnpm install --lockfile-only; then break; fi
+            if [[ $attempt -eq 5 ]]; then echo "❌ lockfile update failed after 5 attempts"; exit 1; fi
+            echo "⏳ Attempt $attempt failed, retrying in 15s (registry propagation)…"; sleep 15
+          done
+
+          {
+            echo "BUMP_SUMMARY<<EOF"
+            for spec in "${specs[@]}"; do echo "- \`${spec%@*}\` → \`^${spec##*@}\`"; done
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+
+      - name: 🔄 Create / update ledger-live PR
+        if: ${{ steps.bump.outputs.bumped == 'true' }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: ledger-live
+          base: develop
+          branch: chore/wallet-api-update
+          delete-branch: true
+          sign-commits: true
+          commit-message: "chore(deps): update wallet-api"
+          title: "chore(deps): update wallet-api"
+          labels: |
+            wallet-api
+            dependencies
+          assignees: ${{ github.actor }}
+          body: |
+            ## 📦 Update wallet-api
+
+            Automated bump of the `@ledgerhq/wallet-api-*` packages published from
+            [`wallet-api`](https://github.com/LedgerHQ/wallet-api).
+
+            ### Updated packages
+
+            ${{ env.BUMP_SUMMARY }}
+
+            ### 🔗 Links
+            - **Release run**: [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
[LIVE-32550](https://ledgerhq.atlassian.net/browse/LIVE-32550)

When wallet-api publishes new package versions, automatically open a PR on ledger-live that
bumps them. A new publish while the PR is still open replaces it.

- new `update-ledger-live` job in `release.yml`, runs when changesets published
- bumps the `@ledgerhq/wallet-api-*` ranges + lockfile in ledger-live (`develop`)
- single fixed branch `chore/wallet-api-update` (so it replaces the open PR)
- PR assigned to the release author

Secrets `GH_BOT_APP_ID` + `GH_BOT_PRIVATE_KEY` are set on this repo (GitHub App installed on ledger-live).

[LIVE-32550]: https://ledgerhq.atlassian.net/browse/LIVE-32550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ