### PR TITLE
feat: add account.getPublicKey Wallet API method

### DIFF
--- a/.changeset/account-get-public-key.md
+++ b/.changeset/account-get-public-key.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/wallet-api-core": minor
+"@ledgerhq/wallet-api-client": minor
+"@ledgerhq/wallet-api-server": minor
+"@ledgerhq/wallet-api-simulator": minor
+---
+
+Add `account.getPublicKey({ accountId, derivationPath? }) -> { publicKey }`. The wallet resolves the key per family in its native encoding (e.g. base58 for Tezos); unsupported families reject with "not implemented".
+
+Deprecate `Account.publicKey` in favor of this method; the field is not populated by the wallet.

--- a/packages/client/src/modules/Account.ts
+++ b/packages/client/src/modules/Account.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   deserializeAccount,
+  schemaAccountGetPublicKey,
   schemaAccountList,
   schemaAccountReceive,
   schemaAccountRequest,
@@ -102,5 +103,36 @@ export class AccountModule {
     );
 
     return safeResults.address;
+  }
+
+  /**
+   * Get the public key of an account from the connected wallet.
+   *
+   * The returned key uses the family's own encoding (e.g. Tezos returns a
+   * base58 public key). Only families with a resolver on the wallet support
+   * this; others reject with a "not implemented" error.
+   *
+   * @param accountId - id of the account
+   * @param derivationPath - optional derivation path (used by UTXO families)
+   *
+   * @returns The account public key
+   * @throws {@link RpcError} if an error occurred on server side
+   */
+  async getPublicKey(
+    accountId: string,
+    derivationPath?: string,
+  ): Promise<string> {
+    const getPublicKeyResult = await this.client.request(
+      "account.getPublicKey",
+      {
+        accountId,
+        derivationPath,
+      },
+    );
+
+    const safeResults =
+      schemaAccountGetPublicKey.result.parse(getPublicKeyResult);
+
+    return safeResults.publicKey;
   }
 }

--- a/packages/core/src/accounts/types.ts
+++ b/packages/core/src/accounts/types.ts
@@ -46,12 +46,7 @@ export type Account = {
 
   parentAccountId?: string;
 
-  /**
-   * The account's public key, in the family's canonical string encoding. Only present for
-   * account-based families that expose a public key distinct from the address; absent where
-   * it is not derivable from the account (e.g. UTXO families). Some dApp flows that need the
-   * public key up front rely on this field.
-   */
+  /** @deprecated Use the `account.getPublicKey` method instead. */
   publicKey?: string;
 };
 

--- a/packages/core/src/spec/methods.ts
+++ b/packages/core/src/spec/methods.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export type MethodId = z.infer<typeof schemaRPCMethod>;
 
 export const schemaRPCMethod = z.enum([
+  "account.getPublicKey",
   "account.list",
   "account.receive",
   "account.request",

--- a/packages/core/src/spec/rpcHandlers/WalletHandlers.ts
+++ b/packages/core/src/spec/rpcHandlers/WalletHandlers.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountGetPublicKeyHandler,
   AccountListHandler,
   AccountReceiveHandler,
   AccountRequestHandler,
@@ -33,6 +34,7 @@ export type UnknownCustomHandlers = Record<
 >;
 
 export type WalletHandlers<GenericCustomHandlers = UnknownCustomHandlers> = {
+  "account.getPublicKey": AccountGetPublicKeyHandler;
   "account.list": AccountListHandler;
   "account.receive": AccountReceiveHandler;
   "account.request": AccountRequestHandler;

--- a/packages/core/src/spec/types/AccountGetPublicKey.ts
+++ b/packages/core/src/spec/types/AccountGetPublicKey.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const schemaAccountGetPublicKeyParams = z.object({
+  accountId: z.string(),
+  derivationPath: z.string().optional(),
+});
+
+const schemaAccountGetPublicKeyResults = z.object({
+  publicKey: z.string(),
+});
+
+export const schemaAccountGetPublicKey = {
+  params: schemaAccountGetPublicKeyParams,
+  result: schemaAccountGetPublicKeyResults,
+};
+
+export type AccountGetPublicKey = {
+  params: z.infer<typeof schemaAccountGetPublicKeyParams>;
+  result: z.infer<typeof schemaAccountGetPublicKeyResults>;
+};
+
+export type AccountGetPublicKeyHandler = (
+  params: AccountGetPublicKey["params"],
+) => AccountGetPublicKey["result"];

--- a/packages/core/src/spec/types/index.ts
+++ b/packages/core/src/spec/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./AccountGetPublicKey";
 export * from "./AccountList";
 export * from "./AccountReceive";
 export * from "./AccountRequest";

--- a/packages/server/src/internalHandlers/account.ts
+++ b/packages/server/src/internalHandlers/account.ts
@@ -1,8 +1,10 @@
 import {
+  AccountGetPublicKey,
   AccountList,
   AccountReceive,
   AccountRequest,
   createNotImplementedByWallet,
+  schemaAccountGetPublicKey,
   schemaAccountList,
   schemaAccountReceive,
   schemaAccountRequest,
@@ -67,6 +69,26 @@ export const list: RPCHandler<AccountList["result"]> = async (
 
   return {
     rawAccounts: accounts.map(serializeAccount),
+  };
+};
+
+export const getPublicKey: RPCHandler<AccountGetPublicKey["result"]> = async (
+  req,
+  _context,
+  handlers,
+) => {
+  const walletHandler = handlers["account.getPublicKey"];
+
+  if (!walletHandler) {
+    throw new ServerError(createNotImplementedByWallet("account.getPublicKey"));
+  }
+
+  const safeParams = schemaAccountGetPublicKey.params.parse(req.params);
+
+  const { accountId, derivationPath } = safeParams;
+
+  return {
+    publicKey: await walletHandler({ accountId, derivationPath }),
   };
 };
 

--- a/packages/server/src/internalHandlers/index.ts
+++ b/packages/server/src/internalHandlers/index.ts
@@ -16,6 +16,7 @@ export const internalHandlers = {
   "account.request": account.request,
   "account.list": account.list,
   "account.receive": account.receive,
+  "account.getPublicKey": account.getPublicKey,
 
   "currency.list": currency.list,
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   Account,
+  AccountGetPublicKey,
   BitcoinGetAddress,
   BitcoinGetAddresses,
   BitcoinGetPublicKey,
@@ -84,6 +85,9 @@ export type WalletHandlers = {
     tokenCurrency?: string;
   }) => Promisable<string>;
   "account.list": (params: { currencyIds?: string[] }) => Promisable<Account[]>;
+  "account.getPublicKey": (
+    params: AccountGetPublicKey["params"],
+  ) => Promisable<string>;
   "currency.list": (params: {
     currencyIds?: string[];
   }) => Promisable<Currency[]>;

--- a/packages/simulator/src/profiles/standard/index.ts
+++ b/packages/simulator/src/profiles/standard/index.ts
@@ -30,6 +30,7 @@ export const standardProfile: SimulatorProfile = {
       "account.request",
       "currency.list",
       "account.list",
+      "account.getPublicKey",
       "transaction.signAndBroadcast",
       "transaction.sign",
       "message.sign",
@@ -86,6 +87,7 @@ export const standardProfile: SimulatorProfile = {
       Buffer.from("0x123O182493423928734983247923847293847293847923847293487"),
     "message.sign": () => Buffer.from("0x123456789123456789"),
     "account.receive": () => "eth address",
+    "account.getPublicKey": () => "publicKey",
     "storage.set": ({ value, key, storeId }) => {
       storage[storeId] ??= new Map();
 

--- a/packages/simulator/tests/simulator.spec.ts
+++ b/packages/simulator/tests/simulator.spec.ts
@@ -376,6 +376,42 @@ describe("Simulator", () => {
     });
   });
 
+  describe("account.getPublicKey", () => {
+    it("should return the publicKey", async () => {
+      // GIVEN
+      const transport = getSimulatorTransport(profiles.STANDARD);
+      const client = new WalletAPIClient(transport);
+
+      // WHEN
+      const publicKey = await client.account.getPublicKey("account-eth-1");
+
+      // THEN
+      expect(publicKey).toBe("publicKey");
+    });
+
+    it("should throw an error if permission not granted", async () => {
+      // GIVEN
+      const transport = getSimulatorTransport(profileWithNoPermissions);
+      const client = new WalletAPIClient(transport);
+
+      // THEN
+      await expect(client.account.getPublicKey("accountId")).rejects.toThrow(
+        "permission",
+      );
+    });
+
+    it("should throw an error if method not handled by server", async () => {
+      // GIVEN
+      const transport = getSimulatorTransport(profileWithUnhandledMethods);
+      const client = new WalletAPIClient(transport);
+
+      // THEN
+      await expect(client.account.getPublicKey("accountId")).rejects.toThrow(
+        "not implemented",
+      );
+    });
+  });
+
   describe("currency.list", () => {
     it("should return a list of currencies", async () => {
       // GIVEN


### PR DESCRIPTION
Adds a generic `account.getPublicKey` method to the Wallet API, letting a connected wallet return an account's public key over RPC. Modeled on the existing `bitcoin.getPublicKey`, but namespaced under `account` so any family can supply a resolver.

```
account.getPublicKey({ accountId: string, derivationPath?: string }) -> { publicKey: string }
```

- `core`: new `AccountGetPublicKey` spec (zod params/result + handler type), exported and added to the `WalletHandlers` map
- `server`: handler-map type plus an internal RPC handler that forwards to the wallet-side handler, rejecting with `notImplementedByWallet` when none is registered
- `client`: `account.getPublicKey(accountId, derivationPath?)` returning the parsed `publicKey`
- `simulator`: capability entry, stub, and tests covering the success, missing-permission, and not-implemented paths

Behavior notes:

- `derivationPath` is optional, matching `bitcoin.getPublicKey` — families that derive keys at a path can use it; others ignore it.
- `publicKey` is returned in the family's own encoding; the result schema is `z.string()`.
- Fail-closed: no resolver is registered in this package, so a wallet that does not implement one rejects. The method is opt-in per family.

Backward-compatible — an additive method on the shared packages. Peers that don't implement it reject with the standard "not implemented" error rather than failing to parse.

Minor bump for `wallet-api-core`, `-client`, `-server`, and `-simulator` via changeset.
