### PR TITLE
feat(core): add account readiness status to wallet API

### DIFF
--- a/.changeset/account-readiness.md
+++ b/.changeset/account-readiness.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add an optional `readiness` field to the `Account` type to let live-apps know whether an account is ready for outgoing operations (send, swap, etc.).
+
+The field is a structured object `{ ready: boolean; reason?: string }` and stays chain-agnostic, covering activation concepts such as Tezos key revelation and Sei address association. A documented starter set of `reason` values is exported as `AccountReadinessReason` (e.g. `"activationRequired"`). When `readiness` is omitted, the account is assumed ready.

--- a/packages/core/src/accounts/serializers.ts
+++ b/packages/core/src/accounts/serializers.ts
@@ -20,6 +20,7 @@ export function serializeAccount({
   lastSyncDate,
   parentAccountId,
   publicKey,
+  readiness,
 }: Account): RawAccount {
   return {
     id,
@@ -32,6 +33,7 @@ export function serializeAccount({
     lastSyncDate: lastSyncDate.toISOString(),
     parentAccountId,
     publicKey,
+    readiness,
   };
 }
 
@@ -53,6 +55,7 @@ export function deserializeAccount({
   lastSyncDate,
   parentAccountId,
   publicKey,
+  readiness,
 }: RawAccount): Account {
   return {
     id,
@@ -65,5 +68,6 @@ export function deserializeAccount({
     lastSyncDate: new Date(lastSyncDate),
     parentAccountId,
     publicKey,
+    readiness,
   };
 }

--- a/packages/core/src/accounts/types.ts
+++ b/packages/core/src/accounts/types.ts
@@ -48,7 +48,66 @@ export type Account = {
 
   /** @deprecated Use the `account.getPublicKey` method instead. */
   publicKey?: string;
+
+  /**
+   * Readiness of the account for outgoing operations (send, swap, etc.).
+   *
+   * When omitted, the account is assumed to be ready. This preserves the
+   * behavior for currencies that have no activation concept.
+   *
+   * @see [[AccountReadiness]]
+   */
+  readiness?: AccountReadiness;
 };
+
+/**
+ * Describes whether an [[Account]] is ready to perform outgoing operations
+ * (send, swap, etc.).
+ *
+ * Some blockchains require a one-time, on-chain activation before an account
+ * can transact normally — e.g. Tezos public-key revelation, or Sei address
+ * association. Until that happens, outgoing operations may be blocked, carry an
+ * extra fee, or be rejected by third-party providers.
+ */
+export type AccountReadiness = {
+  /**
+   * Whether the account can currently perform outgoing operations.
+   */
+  ready: boolean;
+  /**
+   * Machine-readable reason explaining why the account is not ready, so that a
+   * live-app can guide the user (e.g. by showing an activation call-to-action).
+   *
+   * This is intentionally an open string to remain chain-agnostic: new cases
+   * can be introduced without a breaking schema change. Prefer one of the
+   * documented values in [[AccountReadinessReason]] when applicable.
+   */
+  reason?: AccountReadinessReason;
+};
+
+/**
+ * Documented starter set of values for [[AccountReadiness.reason]].
+ *
+ * This is not an exhaustive enum: [[AccountReadiness.reason]] accepts any
+ * string. These constants exist to give producers and consumers a shared
+ * vocabulary for the common cases and to enable editor autocompletion.
+ */
+export const AccountReadinessReason = {
+  /**
+   * The account requires a one-time, on-chain activation before it can perform
+   * outgoing operations (e.g. Tezos key revelation, Sei address association).
+   */
+  ActivationRequired: "activationRequired",
+} as const;
+
+/**
+ * The reason why an account is not ready. One of the documented values in
+ * [[AccountReadinessReason]], or any other string to remain extensible.
+ */
+export type AccountReadinessReason =
+  | (typeof AccountReadinessReason)[keyof typeof AccountReadinessReason]
+  // Allow arbitrary strings while keeping autocompletion on the known values.
+  | (string & {});
 
 /**
  * The raw representation of the [[Account]] type

--- a/packages/core/src/accounts/validation.ts
+++ b/packages/core/src/accounts/validation.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+export const schemaAccountReadiness = z.object({
+  ready: z.boolean(),
+  // `reason` is intentionally a free-form, non-empty string to stay chain-agnostic.
+  // Producers should prefer a documented value from `AccountReadinessReason`
+  // (see accounts/types.ts) — keep the two in sync; do not narrow this to an enum.
+  reason: z.string().min(1).optional(),
+});
+
 export const schemaRawAccount = z.object({
   id: z.string(),
   name: z.string(),
@@ -11,4 +19,5 @@ export const schemaRawAccount = z.object({
   lastSyncDate: z.string(),
   parentAccountId: z.string().optional(),
   publicKey: z.string().optional(),
+  readiness: schemaAccountReadiness.optional(),
 });

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -49,6 +49,9 @@ import {
   RawHederaTransaction,
   HederaTransaction,
   schemaRawTransaction,
+  schemaRawAccount,
+  schemaAccountReadiness,
+  AccountReadinessReason,
 } from "../src";
 
 const date = new Date();
@@ -93,6 +96,68 @@ describe("serializers.ts", () => {
 
       expect(serializedAccount.publicKey).toBe("a-public-key");
     });
+
+    it("should serialize the optional readiness when present", () => {
+      const serializedAccount = serializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: new BigNumber(0),
+        spendableBalance: new BigNumber(0),
+        blockHeight: 0,
+        lastSyncDate: date,
+        readiness: { ready: false, reason: "activationRequired" },
+      });
+
+      expect(serializedAccount.readiness).toEqual({
+        ready: false,
+        reason: "activationRequired",
+      });
+    });
+
+    it("should serialize readiness without a reason", () => {
+      const serializedAccount = serializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: new BigNumber(0),
+        spendableBalance: new BigNumber(0),
+        blockHeight: 0,
+        lastSyncDate: date,
+        readiness: { ready: true },
+      });
+
+      expect(serializedAccount.readiness).toEqual({ ready: true });
+    });
+
+    it("should serialize an account without readiness", () => {
+      const serializedAccount = serializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: new BigNumber(0),
+        spendableBalance: new BigNumber(0),
+        blockHeight: 0,
+        lastSyncDate: date,
+      });
+
+      // `toEqual` treats a `readiness: undefined` own-key as equal to an omitted
+      // key, and `JSON.stringify` drops it on the wire — so the absent case stays
+      // backward-compatible. Do not switch this to `toStrictEqual`.
+      expect(serializedAccount).toEqual({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: "0",
+        spendableBalance: "0",
+        blockHeight: 0,
+        lastSyncDate: date.toISOString(),
+      });
+    });
   });
 
   describe("deserializeAccount", () => {
@@ -134,6 +199,103 @@ describe("serializers.ts", () => {
       });
 
       expect(deserializedAccount.publicKey).toBe("a-public-key");
+    });
+
+    it("should deserialize the optional readiness when present", () => {
+      const deserializedAccount = deserializeAccount({
+        id: "id",
+        name: "name",
+        address: "address",
+        currency: "currency",
+        balance: "0",
+        spendableBalance: "0",
+        blockHeight: 0,
+        lastSyncDate: date.toISOString(),
+        readiness: { ready: false, reason: "activationRequired" },
+      });
+
+      expect(deserializedAccount.readiness).toEqual({
+        ready: false,
+        reason: "activationRequired",
+      });
+    });
+  });
+
+  describe("schemaRawAccount / readiness", () => {
+    const validRaw = {
+      id: "id",
+      name: "name",
+      address: "address",
+      currency: "currency",
+      balance: "0",
+      spendableBalance: "0",
+      blockHeight: 0,
+      lastSyncDate: date.toISOString(),
+    };
+
+    it("should accept and preserve a readiness with a reason", () => {
+      const parsed = schemaRawAccount.parse({
+        ...validRaw,
+        readiness: { ready: false, reason: "activationRequired" },
+      });
+
+      expect(parsed.readiness).toEqual({
+        ready: false,
+        reason: "activationRequired",
+      });
+    });
+
+    it("should accept a readiness without a reason", () => {
+      const parsed = schemaRawAccount.parse({
+        ...validRaw,
+        readiness: { ready: true },
+      });
+
+      expect(parsed.readiness).toEqual({ ready: true });
+    });
+
+    it("should accept an account without readiness", () => {
+      const parsed = schemaRawAccount.parse(validRaw);
+
+      expect(parsed.readiness).toBeUndefined();
+    });
+
+    it("should accept the documented AccountReadinessReason constant", () => {
+      const parsed = schemaAccountReadiness.parse({
+        ready: false,
+        reason: AccountReadinessReason.ActivationRequired,
+      });
+
+      expect(parsed.reason).toBe("activationRequired");
+    });
+
+    it("should accept an arbitrary non-documented reason (open string)", () => {
+      const parsed = schemaAccountReadiness.parse({
+        ready: false,
+        reason: "someFutureChainReason",
+      });
+
+      expect(parsed.reason).toBe("someFutureChainReason");
+    });
+
+    it("should reject a readiness missing the required ready field", () => {
+      expect(() => schemaAccountReadiness.parse({ reason: "x" })).toThrow();
+    });
+
+    it("should reject a non-boolean ready", () => {
+      expect(() => schemaAccountReadiness.parse({ ready: "yes" })).toThrow();
+    });
+
+    it("should reject a non-string reason", () => {
+      expect(() =>
+        schemaAccountReadiness.parse({ ready: true, reason: 123 }),
+      ).toThrow();
+    });
+
+    it("should reject an empty reason", () => {
+      expect(() =>
+        schemaAccountReadiness.parse({ ready: false, reason: "" }),
+      ).toThrow();
     });
   });
 
@@ -2066,6 +2228,27 @@ describe("serializers.ts", () => {
           spendableBalance: new BigNumber(0),
           blockHeight: 0,
           lastSyncDate: date,
+        };
+
+        const serializedAccount = serializeAccount(account);
+        const stringifiedAccount = JSON.stringify(serializedAccount);
+        const parsedAccount = JSON.parse(stringifiedAccount) as RawAccount;
+        const expectedAccount = deserializeAccount(parsedAccount);
+
+        expect(account).toEqual(expectedAccount);
+      });
+
+      it("should not alter account with readiness", () => {
+        const account: Account = {
+          id: "id",
+          name: "name",
+          address: "address",
+          currency: "currency",
+          balance: new BigNumber(0),
+          spendableBalance: new BigNumber(0),
+          blockHeight: 0,
+          lastSyncDate: date,
+          readiness: { ready: false, reason: "activationRequired" },
         };
 
         const serializedAccount = serializeAccount(account);


### PR DESCRIPTION
Add an optional `readiness` field to the `Account` type so live-apps can tell whether an account is ready for outgoing operations (send, swap, etc.).

The field is a chain-agnostic `{ ready: boolean; reason?: string }` object covering activation concepts such as Tezos key revelation and Sei address association. A documented starter set of `reason` values is exported as `AccountReadinessReason` (e.g. `"activationRequired"`). When `readiness` is omitted, the account is assumed ready, preserving existing behavior.

Changes:
- types: add `AccountReadiness` type, optional `Account.readiness` field, and the `AccountReadinessReason` open-string vocabulary
- validation: add `schemaAccountReadiness`, wired into `schemaRawAccount`; `reason` is a non-empty string (`min(1)`) to reject blank values, with a comment linking it to `AccountReadinessReason` to prevent schema/type drift
- serializers: pass `readiness` through serialize/deserialize
- tests: cover the zod schema directly (positive, omitted, and negative cases), the `ready: true`/no-reason and omitted-readiness paths, and a readiness-bearing serialize → deserialize round-trip

Backward compatible (additive optional field); shipped as a `minor` bump.