### PR TITLE
feat(core): add aleo coin family for public transfers

### DIFF
--- a/.changeset/aleo-family.md
+++ b/.changeset/aleo-family.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add the `aleo` coin family (public transfer): types, Zod schema, and serializer for a native ALEO public transfer over the Wallet API.

--- a/packages/core/src/families/aleo/serializer.ts
+++ b/packages/core/src/families/aleo/serializer.ts
@@ -1,0 +1,30 @@
+import BigNumber from "bignumber.js";
+import type { AleoTransaction, RawAleoTransaction } from "./types";
+
+export const serializeAleoTransaction = ({
+  family,
+  mode,
+  fees,
+  amount,
+  recipient,
+}: AleoTransaction): RawAleoTransaction => ({
+  family,
+  amount: amount.toString(),
+  recipient,
+  fees: fees.toString(),
+  mode,
+});
+
+export const deserializeAleoTransaction = ({
+  family,
+  mode,
+  fees,
+  amount,
+  recipient,
+}: RawAleoTransaction): AleoTransaction => ({
+  family,
+  amount: new BigNumber(amount),
+  recipient,
+  fees: new BigNumber(fees),
+  mode,
+});

--- a/packages/core/src/families/aleo/types.ts
+++ b/packages/core/src/families/aleo/types.ts
@@ -1,0 +1,17 @@
+import type BigNumber from "bignumber.js";
+import type { z } from "zod";
+import type { TransactionCommon } from "../index";
+import type {
+  schemaAleoOperationMode,
+  schemaRawAleoTransaction,
+} from "./validation";
+
+export type AleoOperationMode = z.infer<typeof schemaAleoOperationMode>;
+
+export type AleoTransaction = TransactionCommon & {
+  readonly family: RawAleoTransaction["family"];
+  mode: AleoOperationMode;
+  fees: BigNumber;
+};
+
+export type RawAleoTransaction = z.infer<typeof schemaRawAleoTransaction>;

--- a/packages/core/src/families/aleo/validation.ts
+++ b/packages/core/src/families/aleo/validation.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { schemaFamilies, schemaTransactionCommon } from "../common";
+
+export const schemaAleoOperationMode = z.enum(["transfer_public"]);
+
+export const schemaRawAleoTransaction = schemaTransactionCommon.extend({
+  family: z.literal(schemaFamilies.enum.aleo),
+  mode: schemaAleoOperationMode,
+  fees: z.string(),
+});

--- a/packages/core/src/families/common.ts
+++ b/packages/core/src/families/common.ts
@@ -6,6 +6,7 @@ export const schemaTransactionCommon = z.object({
 });
 
 export const FAMILIES = [
+  "aleo",
   "algorand",
   "aptos",
   "bitcoin",

--- a/packages/core/src/families/index.ts
+++ b/packages/core/src/families/index.ts
@@ -1,3 +1,4 @@
+export * from "./aleo/types";
 export * from "./algorand/types";
 export * from "./aptos/types";
 export * from "./bitcoin/types";

--- a/packages/core/src/families/serializer.ts
+++ b/packages/core/src/families/serializer.ts
@@ -1,4 +1,8 @@
 import {
+  deserializeAleoTransaction,
+  serializeAleoTransaction,
+} from "./aleo/serializer";
+import {
   deserializeAlgorandTransaction,
   serializeAlgorandTransaction,
 } from "./algorand/serializer";
@@ -113,6 +117,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeBitcoinTransaction(transaction);
     case "algorand":
       return serializeAlgorandTransaction(transaction);
+    case "aleo":
+      return serializeAleoTransaction(transaction);
     case "aptos":
       return serializeAptosTransaction(transaction);
     case "crypto_org":
@@ -184,6 +190,8 @@ export function deserializeTransaction(
       return deserializeBitcoinTransaction(rawTransaction);
     case "algorand":
       return deserializeAlgorandTransaction(rawTransaction);
+    case "aleo":
+      return deserializeAleoTransaction(rawTransaction);
     case "aptos":
       return deserializeAptosTransaction(rawTransaction);
     case "crypto_org":

--- a/packages/core/src/families/types.ts
+++ b/packages/core/src/families/types.ts
@@ -1,5 +1,6 @@
 import type BigNumber from "bignumber.js";
 import type { z } from "zod";
+import type { AleoTransaction } from "./aleo/types";
 import type { AlgorandTransaction } from "./algorand/types";
 import type { AptosTransaction } from "./aptos/types";
 import type { BitcoinTransaction } from "./bitcoin/types";
@@ -74,6 +75,7 @@ export type Transaction =
   | BitcoinTransaction
   | AlgorandTransaction
   | AptosTransaction
+  | AleoTransaction
   | CryptoOrgTransaction
   | HederaTransaction
   | KaspaTransaction

--- a/packages/core/src/families/validation.ts
+++ b/packages/core/src/families/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { schemaRawAleoTransaction } from "./aleo/validation";
 import { schemaRawAlgorandTransaction } from "./algorand/validation";
 import { schemaRawAptosTransaction } from "./aptos/validation";
 import { schemaRawBitcoinTransaction } from "./bitcoin/validation";
@@ -27,6 +28,7 @@ import { schemaRawCasperTransaction } from "./casper/validation";
 import { schemaRawSuiTransaction } from "./sui/validation";
 
 export const schemaRawTransaction = z.discriminatedUnion("family", [
+  schemaRawAleoTransaction,
   schemaRawAlgorandTransaction,
   schemaRawAptosTransaction,
   schemaRawBitcoinTransaction,

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import {
   Account,
+  AleoTransaction,
   AlgorandTransaction,
   BitcoinTransaction,
   CosmosTransaction,
@@ -12,6 +13,7 @@ import {
   schemaFamilies,
   PolkadotTransaction,
   RawAccount,
+  RawAleoTransaction,
   RawAlgorandTransaction,
   RawAptosTransaction,
   RawBitcoinTransaction,
@@ -1214,6 +1216,29 @@ describe("serializers.ts", () => {
         });
       });
     });
+
+    describe("aleo", () => {
+      const family = schemaFamilies.enum.aleo;
+
+      it("should serialize an Aleo transfer_public transaction", () => {
+        const transaction: AleoTransaction = {
+          family,
+          amount: new BigNumber(1000),
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: new BigNumber(100),
+        };
+        const serializedTransaction = serializeTransaction(transaction);
+
+        expect(serializedTransaction).toEqual({
+          family,
+          amount: "1000",
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: "100",
+        });
+      });
+    });
   });
 
   describe("deserializeTransaction", () => {
@@ -2100,6 +2125,64 @@ describe("serializers.ts", () => {
           mode: "send",
           fees: undefined,
         });
+      });
+    });
+
+    describe("aleo", () => {
+      const family = schemaFamilies.enum.aleo;
+
+      it("should deserialize an Aleo transfer_public transaction", () => {
+        const transaction: RawAleoTransaction = {
+          family,
+          amount: "1000",
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: "100",
+        };
+        const deserializedTransaction = deserializeTransaction(transaction);
+
+        expect(deserializedTransaction).toEqual({
+          family,
+          amount: new BigNumber(1000),
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: new BigNumber(100),
+        });
+      });
+
+      it("should accept a valid raw Aleo transaction", () => {
+        const result = schemaRawTransaction.safeParse({
+          family,
+          amount: "1000",
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: "100",
+        });
+
+        expect(result.success).toBe(true);
+      });
+
+      it("should reject a raw Aleo transaction missing the required fees", () => {
+        const result = schemaRawTransaction.safeParse({
+          family,
+          amount: "1",
+          recipient: "r",
+          mode: "transfer_public",
+        });
+
+        expect(result.success).toBe(false);
+      });
+
+      it("should reject a raw Aleo transaction with an unsupported mode", () => {
+        const result = schemaRawTransaction.safeParse({
+          family,
+          amount: "1",
+          recipient: "r",
+          mode: "transfer_private",
+          fees: "100",
+        });
+
+        expect(result.success).toBe(false);
       });
     });
 


### PR DESCRIPTION
Adds the aleo family (types, Zod schema, serializer) to @ledgerhq/wallet-api-core, modeling the transfer_public mode with a required string-encoded fee. Includes round-trip and validation tests and a changeset.

LIVE-33225