### PR TITLE
feat(LIVE-33225): add aleo support

### DIFF
--- a/.changeset/orange-parrots-carry.md
+++ b/.changeset/orange-parrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+feat: add Aleo support

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Each wallet and application then needs to implement this interface. In this repo
 | icon                              | ❌         | ✅           |
 | zksync (ethereum)                 | ✅         | ✅           |
 | babylon                           | ✅         | ✅           |
+| aleo                              | ✅         | ✅           |
 
 # Where to get help
 

--- a/apps/docs/content/docs/discover/wallet-api/appendix/families.mdx
+++ b/apps/docs/content/docs/discover/wallet-api/appendix/families.mdx
@@ -12,6 +12,10 @@ Please note that actual available cryptocurrencies implementation will depend on
 
 Here are the currently supported cryptocurrency families and their transaction specificities:
 
+### `aleo`
+
+The `aleo` family is used to interact with the Aleo cryptocurrency.
+
 ### `algorand`
 
 The `algorand` family is used to interact with the Algorand cryptocurrency and its "assets".

--- a/packages/core/src/families/aleo/serializer.ts
+++ b/packages/core/src/families/aleo/serializer.ts
@@ -1,0 +1,34 @@
+import BigNumber from "bignumber.js";
+import type { AleoTransaction, RawAleoTransaction } from "./types";
+
+export function serializeAleoTransaction({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+}: AleoTransaction): RawAleoTransaction {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    mode,
+    fees: fees.toString(),
+  };
+}
+
+export function deserializeAleoTransaction({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+}: RawAleoTransaction): AleoTransaction {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    mode,
+    fees: new BigNumber(fees),
+  };
+}

--- a/packages/core/src/families/aleo/types.ts
+++ b/packages/core/src/families/aleo/types.ts
@@ -1,0 +1,17 @@
+import type BigNumber from "bignumber.js";
+import type { z } from "zod";
+import type { TransactionCommon } from "../index";
+import type {
+  schemaAleoOperationMode,
+  schemaRawAleoTransaction,
+} from "./validation";
+
+export type AleoOperationMode = z.infer<typeof schemaAleoOperationMode>;
+
+export type AleoTransaction = TransactionCommon & {
+  readonly family: RawAleoTransaction["family"];
+  mode: AleoOperationMode;
+  fees: BigNumber;
+};
+
+export type RawAleoTransaction = z.infer<typeof schemaRawAleoTransaction>;

--- a/packages/core/src/families/aleo/validation.ts
+++ b/packages/core/src/families/aleo/validation.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { schemaFamilies, schemaTransactionCommon } from "../common";
+
+export const schemaAleoOperationMode = z.enum(["transfer_public"]);
+
+export const schemaRawAleoTransaction = schemaTransactionCommon.extend({
+  family: z.literal(schemaFamilies.enum.aleo),
+  mode: schemaAleoOperationMode,
+  fees: z.string(),
+});

--- a/packages/core/src/families/common.ts
+++ b/packages/core/src/families/common.ts
@@ -6,6 +6,7 @@ export const schemaTransactionCommon = z.object({
 });
 
 export const FAMILIES = [
+  "aleo",
   "algorand",
   "aptos",
   "bitcoin",

--- a/packages/core/src/families/index.ts
+++ b/packages/core/src/families/index.ts
@@ -1,3 +1,4 @@
+export * from "./aleo/types";
 export * from "./algorand/types";
 export * from "./aptos/types";
 export * from "./bitcoin/types";

--- a/packages/core/src/families/serializer.ts
+++ b/packages/core/src/families/serializer.ts
@@ -96,6 +96,10 @@ import {
   serializeSuiTransaction,
   deserializeSuiTransaction,
 } from "./sui/serializer";
+import {
+  deserializeAleoTransaction,
+  serializeAleoTransaction,
+} from "./aleo/serializer";
 import type { RawTransaction, Transaction } from "./types";
 
 /**
@@ -159,6 +163,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeCasperTransaction(transaction);
     case "sui":
       return serializeSuiTransaction(transaction);
+    case "aleo":
+      return serializeAleoTransaction(transaction);
     default: {
       const exhaustiveCheck: never = transaction; // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
       return exhaustiveCheck;
@@ -230,6 +236,8 @@ export function deserializeTransaction(
       return deserializeCasperTransaction(rawTransaction);
     case "sui":
       return deserializeSuiTransaction(rawTransaction);
+    case "aleo":
+      return deserializeAleoTransaction(rawTransaction);
     default: {
       const exhaustiveCheck: never = rawTransaction; // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
       return exhaustiveCheck;

--- a/packages/core/src/families/types.ts
+++ b/packages/core/src/families/types.ts
@@ -28,6 +28,7 @@ import type { StacksTransaction } from "./stacks/types";
 import type { InternetComputerTransaction } from "./internet_computer/types";
 import type { CasperTransaction } from "./casper/types";
 import type { SuiTransaction } from "./sui/types";
+import type { AleoTransaction } from "./aleo/types";
 
 /**
  * Supported coin families
@@ -95,4 +96,5 @@ export type Transaction =
   | StacksTransaction
   | InternetComputerTransaction
   | CasperTransaction
-  | SuiTransaction;
+  | SuiTransaction
+  | AleoTransaction;

--- a/packages/core/src/families/validation.ts
+++ b/packages/core/src/families/validation.ts
@@ -25,6 +25,7 @@ import { schemaRawStacksTransaction } from "./stacks/validation";
 import { schemaRawInternetComputerTransaction } from "./internet_computer/validation";
 import { schemaRawCasperTransaction } from "./casper/validation";
 import { schemaRawSuiTransaction } from "./sui/validation";
+import { schemaRawAleoTransaction } from "./aleo/validation";
 
 export const schemaRawTransaction = z.discriminatedUnion("family", [
   schemaRawAlgorandTransaction,
@@ -53,4 +54,5 @@ export const schemaRawTransaction = z.discriminatedUnion("family", [
   schemaRawInternetComputerTransaction,
   schemaRawCasperTransaction,
   schemaRawSuiTransaction,
+  schemaRawAleoTransaction,
 ]);

--- a/packages/core/tests/serializers.spec.ts
+++ b/packages/core/tests/serializers.spec.ts
@@ -48,6 +48,8 @@ import {
   RawVechainTransaction,
   RawHederaTransaction,
   HederaTransaction,
+  RawAleoTransaction,
+  AleoTransaction,
   schemaRawTransaction,
   schemaRawAccount,
   schemaAccountReadiness,
@@ -948,6 +950,29 @@ describe("serializers.ts", () => {
       it("should succeed to serialize a sui transaction, with options", () => {
         const tx = createTx();
         const rawTx = serializeTransaction({ ...tx, fees: BigNumber(1) });
+
+        expect(rawTx).toEqual({
+          ...tx,
+          amount: "100",
+          fees: "1",
+        });
+      });
+    });
+
+    describe("aleo", () => {
+      function createTx(): AleoTransaction {
+        return {
+          family: schemaFamilies.enum.aleo,
+          amount: BigNumber(100),
+          recipient: "recipient",
+          mode: "transfer_public",
+          fees: BigNumber(1),
+        };
+      }
+
+      it("should succeed to serialize an aleo transaction", () => {
+        const tx = createTx();
+        const rawTx = serializeTransaction(tx);
 
         expect(rawTx).toEqual({
           ...tx,
@@ -1902,6 +1927,29 @@ describe("serializers.ts", () => {
       it("should succeed to deserialize a sui transaction with fees", () => {
         const rawTx = createRawTx();
         const tx = deserializeTransaction({ ...rawTx, fees: "1" });
+
+        expect(tx).toEqual({
+          ...rawTx,
+          amount: new BigNumber(100),
+          fees: new BigNumber(1),
+        });
+      });
+    });
+
+    describe("aleo", () => {
+      function createRawTx(): RawAleoTransaction {
+        return {
+          family: schemaFamilies.enum.aleo,
+          mode: "transfer_public",
+          amount: "100",
+          recipient: "recipient",
+          fees: "1",
+        };
+      }
+
+      it("should succeed to deserialize an aleo transaction", () => {
+        const rawTx = createRawTx();
+        const tx = deserializeTransaction(rawTx);
 
         expect(tx).toEqual({
           ...rawTx,


### PR DESCRIPTION
Adds the `aleo` family (types, Zod schema, serializer) to @ledgerhq/wallet-api-core, modeling the `transfer_public` mode with a required fee.

JIRA ticket: https://ledgerhq.atlassian.net/browse/LIVE-33225