### PR TITLE
chore: remove @ledgerhq/errors dependency

### DIFF
--- a/.changeset/remove-ledgerhq-errors.md
+++ b/.changeset/remove-ledgerhq-errors.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-core": major
+"@ledgerhq/wallet-api-simulator": patch
+---
+
+chore: remove @ledgerhq/errors dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@ledgerhq/errors": "^6.35.0",
     "@stacks/transactions": "^6.13.0",
     "@ton/core": "^0.62.0",
     "bignumber.js": "^9.1.2",

--- a/packages/core/src/JSONRPC/RpcNode.ts
+++ b/packages/core/src/JSONRPC/RpcNode.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { UnknownErrorData } from "../errors";
 import {
   ServerError,
   createUnknownError,
@@ -145,17 +144,10 @@ export abstract class RpcNode<TSHandlers, TCHandlers> {
         throw error;
       }
 
-      const rawError = serializeError(error);
-      const normalizedError: UnknownErrorData =
-        typeof rawError === "string"
-          ? { message: rawError }
-          : typeof rawError === "object" && rawError !== null
-            ? rawError
-            : {};
       throw new RpcError({
         code: RpcErrorCode.SERVER_ERROR,
         message: "unexpected server error",
-        data: createUnknownError(normalizedError),
+        data: createUnknownError(serializeError(error)),
       });
     }
   }

--- a/packages/core/src/JSONRPC/RpcNode.ts
+++ b/packages/core/src/JSONRPC/RpcNode.ts
@@ -1,9 +1,11 @@
-import { deserializeError, serializeError } from "@ledgerhq/errors";
 import { z } from "zod";
+import type { UnknownErrorData } from "../errors";
 import {
   ServerError,
   createUnknownError,
+  deserializeError,
   schemaServerErrorData,
+  serializeError,
 } from "../errors";
 import type { Transport } from "../transports";
 import { RpcError } from "./RPCError";
@@ -143,17 +145,17 @@ export abstract class RpcNode<TSHandlers, TCHandlers> {
         throw error;
       }
 
-      let serializedError = serializeError(
-        error as Parameters<typeof serializeError>[0],
-      );
-      serializedError =
-        typeof serializedError === "string" || !serializedError
-          ? { message: serializedError }
-          : serializedError;
+      const rawError = serializeError(error);
+      const normalizedError: UnknownErrorData =
+        typeof rawError === "string"
+          ? { message: rawError }
+          : typeof rawError === "object" && rawError !== null
+            ? rawError
+            : {};
       throw new RpcError({
         code: RpcErrorCode.SERVER_ERROR,
         message: "unexpected server error",
-        data: createUnknownError(serializedError),
+        data: createUnknownError(normalizedError),
       });
     }
   }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./creators";
 export * from "./ServerError";
+export * from "./serialization";

--- a/packages/core/src/errors/serialization.ts
+++ b/packages/core/src/errors/serialization.ts
@@ -1,13 +1,26 @@
 import type { UnknownErrorData } from "./types";
 
-export function serializeError(
-  error: unknown,
-): UnknownErrorData | string | null | undefined {
+// Always returns a valid wire shape — callers never need to normalize.
+export function serializeError(error: unknown): UnknownErrorData {
   if (error instanceof Error) {
-    return { name: error.name, message: error.message, stack: error.stack };
+    const serialized: UnknownErrorData = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+    // preserve the extra fields the wire schema advertises
+    // (read via cast: the DOM-only `lib` here lacks ES2022 `Error.cause`)
+    const { code, cause } = error as { code?: unknown; cause?: unknown };
+    if (typeof code === "string") serialized.code = code;
+    if (cause !== undefined) serialized.cause = cause;
+    return serialized;
   }
-  if (typeof error === "string") return error;
-  return error as UnknownErrorData | null | undefined;
+  if (typeof error === "string") return { message: error };
+  if (error !== null && typeof error === "object") {
+    return error;
+  }
+  // primitives, null, undefined
+  return {};
 }
 
 // returns undefined when data has no name/message — e.g. `throw undefined` round-trips as {}
@@ -16,8 +29,14 @@ export function deserializeError(
 ): Error | undefined {
   if (!data) return undefined;
   if (data.message === undefined && data.name === undefined) return undefined;
-  const error = new Error(data.message);
+  const error = new Error(data.message) as Error & {
+    code?: string;
+    cause?: unknown;
+  };
   if (data.name) error.name = data.name;
   if (data.stack) error.stack = data.stack;
+  // complete the round-trip for the same extra fields
+  if (data.code !== undefined) error.code = data.code;
+  if (data.cause !== undefined) error.cause = data.cause;
   return error;
 }

--- a/packages/core/src/errors/serialization.ts
+++ b/packages/core/src/errors/serialization.ts
@@ -1,0 +1,23 @@
+import type { UnknownErrorData } from "./types";
+
+export function serializeError(
+  error: unknown,
+): UnknownErrorData | string | null | undefined {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  if (typeof error === "string") return error;
+  return error as UnknownErrorData | null | undefined;
+}
+
+// returns undefined when data has no name/message — e.g. `throw undefined` round-trips as {}
+export function deserializeError(
+  data: UnknownErrorData | null | undefined,
+): Error | undefined {
+  if (!data) return undefined;
+  if (data.message === undefined && data.name === undefined) return undefined;
+  const error = new Error(data.message);
+  if (data.name) error.name = data.name;
+  if (data.stack) error.stack = data.stack;
+  return error;
+}

--- a/packages/core/tests/errors-serialization.spec.ts
+++ b/packages/core/tests/errors-serialization.spec.ts
@@ -1,0 +1,59 @@
+import { deserializeError, serializeError } from "../src";
+
+describe("serializeError", () => {
+  it("serializes an Error to name/message/stack", () => {
+    const out = serializeError(new Error("boom"));
+    expect(out).toMatchObject({ name: "Error", message: "boom" });
+    expect(typeof out.stack).toBe("string");
+  });
+
+  it("preserves a custom name and code", () => {
+    class MyError extends Error {
+      override name = "MyError";
+      code = "E_CUSTOM";
+    }
+    expect(serializeError(new MyError("x"))).toMatchObject({
+      name: "MyError",
+      message: "x",
+      code: "E_CUSTOM",
+    });
+  });
+
+  it("preserves cause", () => {
+    const out = serializeError(
+      Object.assign(new Error("outer"), { cause: new Error("inner") }),
+    );
+    expect(out.cause).toBeInstanceOf(Error);
+  });
+
+  it("wraps a thrown string as { message }", () => {
+    expect(serializeError("nope")).toEqual({ message: "nope" });
+  });
+
+  it("returns {} for primitives / null / undefined", () => {
+    expect(serializeError(42)).toEqual({});
+    expect(serializeError(null)).toEqual({});
+    expect(serializeError(undefined)).toEqual({});
+  });
+});
+
+describe("deserializeError", () => {
+  it("round-trips a serialized Error, including code", () => {
+    const wire = serializeError(
+      Object.assign(new Error("boom"), { code: "E_CUSTOM" }),
+    );
+    const out = deserializeError(wire);
+    expect(out).toBeInstanceOf(Error);
+    expect(out?.message).toBe("boom");
+    expect(out?.code).toBe("E_CUSTOM");
+  });
+
+  it("returns undefined when payload has no name or message", () => {
+    expect(deserializeError({})).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined (e.g. `throw undefined`)", () => {
+    expect(deserializeError(undefined)).toBeUndefined();
+    expect(deserializeError(null)).toBeUndefined();
+  });
+});

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -19,7 +19,6 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@ledgerhq/errors": "^6.35.0",
     "@ledgerhq/jest-shared-config": "workspace:*",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.2",

--- a/packages/simulator/tests/simulator.spec.ts
+++ b/packages/simulator/tests/simulator.spec.ts
@@ -5,6 +5,9 @@ import {
 import BigNumber from "bignumber.js";
 import { getSimulatorTransport, profiles } from "../src";
 
+// Minimal throw fixture — hardcodes UNKNOWN_ERROR since the only status code
+// exercised here (0x6d01) is genuinely unknown. Not a full port of
+// @ledgerhq/errors' TransportStatusError status-name mapping.
 class TransportStatusError extends Error {
   override name = "TransportStatusError";
   constructor(statusCode: number) {
@@ -763,6 +766,7 @@ describe("Simulator", () => {
         methods: {
           ...profiles.STANDARD.methods,
           "message.sign": () => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error -- intentionally throwing a non-Error to exercise serialization
             throw "simple string";
           },
         },
@@ -783,6 +787,7 @@ describe("Simulator", () => {
         methods: {
           ...profiles.STANDARD.methods,
           "message.sign": () => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error -- intentionally throwing a non-Error to exercise serialization
             throw "";
           },
         },
@@ -803,6 +808,7 @@ describe("Simulator", () => {
         methods: {
           ...profiles.STANDARD.methods,
           "message.sign": () => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error -- intentionally throwing undefined to exercise serialization
             throw undefined;
           },
         },

--- a/packages/simulator/tests/simulator.spec.ts
+++ b/packages/simulator/tests/simulator.spec.ts
@@ -1,10 +1,17 @@
-import { TransportStatusError } from "@ledgerhq/errors";
 import {
   WalletAPIClient,
   deserializeAccount,
 } from "@ledgerhq/wallet-api-client";
 import BigNumber from "bignumber.js";
 import { getSimulatorTransport, profiles } from "../src";
+
+class TransportStatusError extends Error {
+  override name = "TransportStatusError";
+  constructor(statusCode: number) {
+    const hex = statusCode.toString(16).padStart(4, "0");
+    super(`Ledger device: UNKNOWN_ERROR (0x${hex})`);
+  }
+}
 
 const profileWithNoPermissions = {
   ...profiles.STANDARD,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
         version: 16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.6.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(patch_hash=c956da7fd77cae4548c8f2f2cb9224d6978338f81b942a6bc2c7692182e65d01)(@types/react@19.2.17)(immer@11.1.8)(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nextra@4.6.1(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        version: 4.6.1(patch_hash=c956da7fd77cae4548c8f2f2cb9224d6978338f81b942a6bc2c7692182e65d01)(@types/react@19.2.17)(immer@11.1.8)(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nextra@4.6.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -352,9 +352,6 @@ importers:
 
   packages/core:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: ^6.35.0
-        version: 6.35.0
       '@stacks/transactions':
         specifier: ^6.13.0
         version: 6.13.0
@@ -579,9 +576,6 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
     devDependencies:
-      '@ledgerhq/errors':
-        specifier: ^6.35.0
-        version: 6.35.0
       '@ledgerhq/jest-shared-config':
         specifier: workspace:*
         version: link:../jest-shared-config
@@ -12842,13 +12836,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(patch_hash=c956da7fd77cae4548c8f2f2cb9224d6978338f81b942a6bc2c7692182e65d01)(@types/react@19.2.17)(immer@11.1.8)(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nextra@4.6.1(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  nextra-theme-docs@4.6.1(patch_hash=c956da7fd77cae4548c8f2f2cb9224d6978338f81b942a6bc2c7692182e65d01)(@types/react@19.2.17)(immer@11.1.8)(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nextra@4.6.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     dependencies:
       '@headlessui/react': 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.0
       next: 16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      nextra: 4.6.1(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      nextra: 4.6.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react: 19.2.7
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
@@ -12860,7 +12854,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  nextra@4.6.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What

Removes the `@ledgerhq/errors` package from `packages/core` (runtime dep) and `packages/simulator` (dev dep).

## Why

`@ledgerhq/errors` brings in a large dependency for two narrow use cases: error serialization over RPC and one error class in a test. Both can be self-contained.

## How

**`packages/core`** — new `src/errors/serialization.ts` with local `serializeError` / `deserializeError`:

- `serializeError` converts `Error` instances to `{ name, message, stack }`, passes strings through, and falls back to an empty object for any other thrown value (primitives, null, undefined) so the client always receives a valid `UnknownErrorData` shape
- `deserializeError` reconstructs an `Error` from the wire payload, returning `undefined` when the data has no `name` or `message` (e.g. `throw undefined` round-trips through JSON as `{}`)

**`packages/simulator`** — `TransportStatusError` defined inline in the test file; it was only used as a throw fixture to exercise error propagation.

> [!NOTE]
> `instanceof` checks on deserialized errors always fail across IPC/serialization boundaries anyway — use `error.name` string comparison instead, which is what the rest of the codebase already does.