### PR TITLE
feat: adding hypercore

### DIFF
--- a/.changeset/add-hypercore-family.md
+++ b/.changeset/add-hypercore-family.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-api-core": minor
+---
+
+Add HyperCore to the Wallet API family registry so hosts can expose its currency metadata.

--- a/apps/docs/content/docs/discover/wallet-api/appendix/families.mdx
+++ b/apps/docs/content/docs/discover/wallet-api/appendix/families.mdx
@@ -56,6 +56,11 @@ The `filecoin` family is used to interact with the Filecoin cryptocurrency.
 
 The `hedera` family is used to interact with the Hedera cryptocurrency.
 
+### `hypercore`
+
+The `hypercore` family exposes Hyperliquid HyperCore currency metadata and accounts. Wallet API
+transactions are not supported for this family.
+
 ### `near`
 
 The `near` family is used to interact with the Near cryptocurrency.

--- a/packages/core/src/families/common.ts
+++ b/packages/core/src/families/common.ts
@@ -19,6 +19,7 @@ export const FAMILIES = [
   "ethereum",
   "filecoin",
   "hedera",
+  "hypercore",
   "internet_computer",
   "kaspa",
   "near",


### PR DESCRIPTION
This pull request adds support for the `hypercore` family to the Wallet API, allowing hosts to expose Hyperliquid HyperCore currency metadata and accounts. Wallet API transactions are not supported for this family. The changes include updating the family registry, documentation, and the core families list.

**Wallet API family registry and core updates:**

* Added `hypercore` to the Wallet API family registry to enable hosts to expose its currency metadata (`.changeset/add-hypercore-family.md`).
* Updated the `FAMILIES` array in `common.ts` to include `hypercore` (`packages/core/src/families/common.ts`).

**Documentation:**

* Documented the new `hypercore` family, describing its purpose and limitations (no transaction support) (`apps/docs/content/docs/discover/wallet-api/appendix/families.mdx`).